### PR TITLE
#28 refactor: ErrorResponseCode

### DIFF
--- a/src/main/java/sync/slamtalk/common/ApiResponse.java
+++ b/src/main/java/sync/slamtalk/common/ApiResponse.java
@@ -61,8 +61,8 @@ public class ApiResponse<T> {
 
 
     // 실패 응답
-    public static <T>ApiResponse<T> fail(ErrorResponseCode errorResponseCode){
-        return new ApiResponse<>(errorResponseCode.getStatus(), errorResponseCode.getMessage());
+    public static <T>ApiResponse<T> fail(ResponseCodeDetails responseCodeInterface){
+        return new ApiResponse<>(responseCodeInterface.getStatus(), responseCodeInterface.getMessage());
     }
 
 

--- a/src/main/java/sync/slamtalk/common/BaseException.java
+++ b/src/main/java/sync/slamtalk/common/BaseException.java
@@ -5,14 +5,14 @@ package sync.slamtalk.common;
    기능별 커스텀 에러 응답을 준다.
 */
 public class BaseException extends RuntimeException{
-    private ErrorResponseCode errorResponseCode = ErrorResponseCode.UNCATEGORIZED;
+    private final ResponseCodeDetails responseCodeInterface;
 
-    public BaseException(ErrorResponseCode errorResponseCode){
+    public BaseException(ResponseCodeDetails responseCodeInterface){
         super("error");
-        this.errorResponseCode = errorResponseCode;
+        this.responseCodeInterface = responseCodeInterface;
     }
 
-    public ErrorResponseCode getErrorCode(){
-        return errorResponseCode;
+    public ResponseCodeDetails getErrorCode(){
+        return responseCodeInterface;
     }
 }

--- a/src/main/java/sync/slamtalk/common/ErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/common/ErrorResponseCode.java
@@ -2,7 +2,7 @@ package sync.slamtalk.common;
 
 import static jakarta.servlet.http.HttpServletResponse.*;
 
-public enum ErrorResponseCode {
+public enum ErrorResponseCode implements ResponseCodeDetails {
 
     OK(SC_OK, 200,"Request Success"),
     INVALID_TOKEN(SC_BAD_REQUEST,4001,"Token Invalid"),
@@ -51,7 +51,4 @@ public enum ErrorResponseCode {
     public String getMessage(){
         return message;
     }
-
-
-
 }

--- a/src/main/java/sync/slamtalk/common/ResponseCodeDetails.java
+++ b/src/main/java/sync/slamtalk/common/ResponseCodeDetails.java
@@ -1,0 +1,22 @@
+package sync.slamtalk.common;
+
+/**
+ * RESTAPI 커스텀 할 때 상속받는 인터셉터
+ * */
+public interface ResponseCodeDetails {
+
+    /*
+     * 커스텀 상태 얻어는 메서드
+     */
+    int getStatus();
+
+    /* 요청 처리 결과에 대한 코드값으로 HTTP Status 코드와는 별개로
+     * 보다 상세한 정보를 나타내야 한다.
+     */
+    int getCode();
+
+    /*
+     * code 가 어떤 메세지를 의미하는지 나타내기 위함
+     */
+    String getMessage();
+}


### PR DESCRIPTION
## 📝 #28 refactor: ErrorResponseCode
 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
-  ResponseCodeDetails 라는 Interface 생성
-  GlobalRestControllerAdivice 및 BaseExcextion, ApiResponse 에서 인터페이스를 반환하고 객체로 사용하도록 수정

## 💬 리뷰 요구사항
- ResponseInterface를 상속받으면 기능별로 커스텀하게 에러를 만들 수 있습니다.(ErrorResponseCode 참고)

resolved: #28 