### PR TITLE
#13 근처 농구장 마커 표시 & 클릭시 해당 시설 정보 표시

### DIFF
--- a/src/main/java/sync/slamtalk/map/controller/BasketballCourtController.java
+++ b/src/main/java/sync/slamtalk/map/controller/BasketballCourtController.java
@@ -1,9 +1,9 @@
 package sync.slamtalk.map.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,18 +21,28 @@ public class BasketballCourtController {
 
     //전체 농구장 간략 정보
     @GetMapping
-    public ResponseEntity<ApiResponse<List<BasketballCourtDto>>> getAllCourtSummaryInfo() {
+    @Operation(
+            summary = "전체 농구장 간략 정보", // 기능 제목 입니다
+            description = "이 기능은 마커에 띄울 전체 농구장의 간략 정보 응답을 보내는 기능입니다.", // 기능 설명
+            tags = {"지도"}
+    )
+    public ApiResponse<List<BasketballCourtDto>> getAllCourtSummaryInfo() {
         List<BasketballCourtDto> courtDetails = basketballCourtService.getAllCourtSummaryInfo();
-        return ResponseEntity.ok(ApiResponse.ok(courtDetails, "농구장 목록을 성공적으로 가져왔습니다."));
+        return (ApiResponse.ok(courtDetails, "농구장 목록을 성공적으로 가져왔습니다."));
     }
 
 
     //특정 농구장 전체 정보
     @GetMapping("/{courtId}")
-    public ResponseEntity<ApiResponse<BasketballCourtDto>> getCourtFullInfoById(@PathVariable Long courtId) {
+    @Operation(
+            summary = "마커 클릭 농구장 전체 정보", // 기능 제목 입니다
+            description = "이 기능은 클릭한 마커에 해당하는 농구장의 전체 정보 응답을 보내는 기능입니다.", // 기능 설명
+            tags = {"지도"}
+    )
+    public ApiResponse<BasketballCourtDto> getCourtFullInfoById(@PathVariable Long courtId) {
         Optional<BasketballCourtDto> basketballCourtDto = basketballCourtService.getCourtFullInfoById(courtId);
         return basketballCourtDto
-                .map(dto -> ResponseEntity.ok(ApiResponse.ok(dto, "농구장 상세 정보를 성공적으로 가져왔습니다.")))
-                .orElseGet(() -> ResponseEntity.ok(ApiResponse.fail("농구장 정보를 찾을 수 없습니다.")));
+                .map(dto -> (ApiResponse.ok(dto, "농구장 상세 정보를 성공적으로 가져왔습니다.")))
+                .orElseGet(() -> (ApiResponse.fail("농구장 정보를 찾을 수 없습니다.")));
     }
 }

--- a/src/main/java/sync/slamtalk/map/controller/BasketballCourtController.java
+++ b/src/main/java/sync/slamtalk/map/controller/BasketballCourtController.java
@@ -1,0 +1,38 @@
+package sync.slamtalk.map.controller;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.map.dto.BasketballCourtDto;
+import sync.slamtalk.map.service.BasketballCourtService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/map")
+public class BasketballCourtController {
+    private final BasketballCourtService basketballCourtService;
+
+
+    //전체 농구장 간략 정보
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BasketballCourtDto>>> getAllCourtSummaryInfo() {
+        List<BasketballCourtDto> courtDetails = basketballCourtService.getAllCourtSummaryInfo();
+        return ResponseEntity.ok(ApiResponse.ok(courtDetails, "농구장 목록을 성공적으로 가져왔습니다."));
+    }
+
+
+    //특정 농구장 전체 정보
+    @GetMapping("/{courtId}")
+    public ResponseEntity<ApiResponse<BasketballCourtDto>> getCourtFullInfoById(@PathVariable Long courtId) {
+        Optional<BasketballCourtDto> basketballCourtDto = basketballCourtService.getCourtFullInfoById(courtId);
+        return basketballCourtDto
+                .map(dto -> ResponseEntity.ok(ApiResponse.ok(dto, "농구장 상세 정보를 성공적으로 가져왔습니다.")))
+                .orElseGet(() -> ResponseEntity.ok(ApiResponse.fail("농구장 정보를 찾을 수 없습니다.")));
+    }
+}

--- a/src/main/java/sync/slamtalk/map/controller/BasketballCourtController.java
+++ b/src/main/java/sync/slamtalk/map/controller/BasketballCourtController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.common.BaseException;
 import sync.slamtalk.map.dto.BasketballCourtDto;
 import sync.slamtalk.map.service.BasketballCourtService;
 
@@ -40,9 +41,10 @@ public class BasketballCourtController {
             tags = {"지도"}
     )
     public ApiResponse<BasketballCourtDto> getCourtFullInfoById(@PathVariable Long courtId) {
-        Optional<BasketballCourtDto> basketballCourtDto = basketballCourtService.getCourtFullInfoById(courtId);
-        return basketballCourtDto
-                .map(dto -> (ApiResponse.ok(dto, "농구장 상세 정보를 성공적으로 가져왔습니다.")))
-                .orElseGet(() -> (ApiResponse.fail("농구장 정보를 찾을 수 없습니다.")));
+
+            BasketballCourtDto basketballCourtDto = basketballCourtService.getCourtFullInfoById(courtId);
+            return ApiResponse.ok(basketballCourtDto, "농구장 상세 정보를 성공적으로 가져왔습니다.");
+
     }
+
 }

--- a/src/main/java/sync/slamtalk/map/dto/BasketballCourtDto.java
+++ b/src/main/java/sync/slamtalk/map/dto/BasketballCourtDto.java
@@ -1,0 +1,53 @@
+package sync.slamtalk.map.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값이 있는 필드는 제외
+public class BasketballCourtDto {
+    private Long courtId;
+    private String courtName;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private String courtType;
+    private String indoorOutdoor;
+    private String courtSize;
+    private Integer hoopCount;
+    private Boolean nightLighting;
+    private String openingHours;
+    private String fee;
+    private Boolean parkingAvailable;
+    private String additionalInfo;
+    private String photoUrl;
+
+    //농구장 전체 정보 dto
+    public BasketballCourtDto(Long courtId, String courtName, BigDecimal latitude, BigDecimal longitude,
+                              String courtType, String indoorOutdoor, String courtSize, Integer hoopCount,
+                              Boolean nightLighting, String openingHours, String fee, Boolean parkingAvailable,
+                              String additionalInfo, String photoUrl) {
+        this.courtId = courtId;
+        this.courtName = courtName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.courtType = courtType;
+        this.indoorOutdoor = indoorOutdoor;
+        this.courtSize = courtSize;
+        this.hoopCount = hoopCount;
+        this.nightLighting = nightLighting;
+        this.openingHours = openingHours;
+        this.fee = fee;
+        this.parkingAvailable = parkingAvailable;
+        this.additionalInfo = additionalInfo;
+        this.photoUrl = photoUrl;
+    }
+
+    // 농구장 간략 정보 dto
+    public BasketballCourtDto(Long courtId, String courtName, BigDecimal latitude, BigDecimal longitude) {
+        this.courtId = courtId;
+        this.courtName = courtName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/sync/slamtalk/map/dto/BasketballCourtErrorResponse.java
+++ b/src/main/java/sync/slamtalk/map/dto/BasketballCourtErrorResponse.java
@@ -1,0 +1,34 @@
+package sync.slamtalk.map.dto;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import sync.slamtalk.common.ResponseCodeDetails;
+
+public enum BasketballCourtErrorResponse implements ResponseCodeDetails {
+    MAP_FAIL(SC_BAD_REQUEST,4041,"Court Not Found")
+    ;
+
+    private final int code;
+    private int status;
+    private final String message;
+
+    BasketballCourtErrorResponse(int code, int status, String message) {
+        this.code = code;
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public int getCode() {
+        return 0;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/src/main/java/sync/slamtalk/map/entity/AdminStatus.java
+++ b/src/main/java/sync/slamtalk/map/entity/AdminStatus.java
@@ -1,0 +1,9 @@
+package sync.slamtalk.map.entity;
+
+// 관리자 상태 ( 수락, 거절, 대기, 삭제)
+public enum AdminStatus {
+    ACCEPT,
+    REJECT,
+    STAND,
+    DELETE
+}

--- a/src/main/java/sync/slamtalk/map/entity/BasketballCourt.java
+++ b/src/main/java/sync/slamtalk/map/entity/BasketballCourt.java
@@ -1,0 +1,81 @@
+package sync.slamtalk.map.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sync.slamtalk.chat.entity.ChatRoom;
+import sync.slamtalk.common.BaseEntity;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "BasketballCourt")
+public class BasketballCourt extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "court_id", nullable = false)
+    private Long courtId; // 농구장 ID
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id", nullable = false)
+    private ChatRoom chatroom; // 채팅방 ID
+
+    @Column(name = "court_name", nullable = false, length = 50)
+    private String courtName; // 농구장 이름
+
+    @Column(name = "latitude", precision = 13, scale = 10, nullable = false)
+    private BigDecimal latitude; // 농구장 위도
+
+    @Column(name = "longitude", precision = 13, scale = 10, nullable = false)
+    private BigDecimal longitude; //농구장 경도
+
+    @Column(name = "court_type", length = 50)
+    private String courtType; //코트 종류
+
+    @Column(name = "indoor_outdoor", length = 20)
+    private String indoorOutdoor; //실내외
+
+    @Column(name = "court_size", length = 50)
+    private String courtSize; // 코트 사이즈
+
+    @Column(name = "hoop_count")
+    private Integer hoopCount; // 골대 수
+
+    @Column(name = "night_lighting")
+    private Boolean nightLighting; // 야간 조명 유무
+
+    @Column(name = "opening_hours", length = 50)
+    private String openingHours; // 개방 시간
+
+    @Column(name = "fee", length = 100)
+    private String fee; // 사용료
+
+    @Column(name = "parking_available")
+    private Boolean parkingAvailable; // 주차 가능 여부
+
+    @Column(name = "additional_info", columnDefinition = "TEXT")
+    private String additionalInfo; //기타 내용
+
+    @Column(name = "photo_url", length = 255)
+    private String photoUrl; // 농구장 사진 url
+
+    @Column(name = "admin_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AdminStatus adminStatus; // 관리자 상태
+
+}

--- a/src/main/java/sync/slamtalk/map/mapper/BasketballCourtMapper.java
+++ b/src/main/java/sync/slamtalk/map/mapper/BasketballCourtMapper.java
@@ -1,0 +1,44 @@
+package sync.slamtalk.map.mapper;
+
+import org.springframework.stereotype.Component;
+import sync.slamtalk.map.dto.BasketballCourtDto;
+import sync.slamtalk.map.entity.BasketballCourt;
+
+@Component
+public class BasketballCourtMapper {
+
+    // entity -> dto 변환
+    public BasketballCourtDto toDto(BasketballCourt basketballCourt) {
+        if (basketballCourt == null) {
+            return null;
+        }
+        return new BasketballCourtDto(
+                basketballCourt.getCourtId(),
+                basketballCourt.getCourtName(),
+                basketballCourt.getLatitude(),
+                basketballCourt.getLongitude()
+        );
+    }
+
+    public BasketballCourtDto toFullDto(BasketballCourt basketballCourt) {
+        if (basketballCourt == null) {
+            return null;
+        }
+        return new BasketballCourtDto(
+                basketballCourt.getCourtId(),
+                basketballCourt.getCourtName(),
+                basketballCourt.getLatitude(),
+                basketballCourt.getLongitude(),
+                basketballCourt.getCourtType(),
+                basketballCourt.getIndoorOutdoor(),
+                basketballCourt.getCourtSize(),
+                basketballCourt.getHoopCount(),
+                basketballCourt.getNightLighting(),
+                basketballCourt.getOpeningHours(),
+                basketballCourt.getFee(),
+                basketballCourt.getParkingAvailable(),
+                basketballCourt.getAdditionalInfo(),
+                basketballCourt.getPhotoUrl()
+        );
+    }
+}

--- a/src/main/java/sync/slamtalk/map/repository/BasketballCourtRepository.java
+++ b/src/main/java/sync/slamtalk/map/repository/BasketballCourtRepository.java
@@ -1,0 +1,11 @@
+package sync.slamtalk.map.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sync.slamtalk.map.entity.BasketballCourt;
+
+@Repository
+public interface BasketballCourtRepository extends JpaRepository<BasketballCourt, Long> {
+
+
+}

--- a/src/main/java/sync/slamtalk/map/service/BasketballCourtService.java
+++ b/src/main/java/sync/slamtalk/map/service/BasketballCourtService.java
@@ -5,7 +5,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import sync.slamtalk.common.BaseException;
+import sync.slamtalk.common.ErrorResponseCode;
 import sync.slamtalk.map.dto.BasketballCourtDto;
+import sync.slamtalk.map.dto.BasketballCourtErrorResponse;
 import sync.slamtalk.map.entity.AdminStatus;
 import sync.slamtalk.map.mapper.BasketballCourtMapper;
 import sync.slamtalk.map.repository.BasketballCourtRepository;
@@ -26,10 +29,11 @@ public class BasketballCourtService {
     }
 
     //특정 농구장 전체 정보
-    public Optional<BasketballCourtDto> getCourtFullInfoById(Long courtId) {
+    public BasketballCourtDto getCourtFullInfoById(Long courtId) {
         return basketballCourtRepository.findById(courtId)
                 .filter(court -> court.getAdminStatus() == AdminStatus.ACCEPT) // ACCEPT 상태 필터링
-                .map(basketballCourtMapper::toFullDto); // dto 변환 mapper 호출
+                .map(basketballCourtMapper::toFullDto)
+                .orElseThrow(()->new BaseException(BasketballCourtErrorResponse.MAP_FAIL));
     }
 
 }

--- a/src/main/java/sync/slamtalk/map/service/BasketballCourtService.java
+++ b/src/main/java/sync/slamtalk/map/service/BasketballCourtService.java
@@ -1,0 +1,35 @@
+package sync.slamtalk.map.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sync.slamtalk.map.dto.BasketballCourtDto;
+import sync.slamtalk.map.entity.AdminStatus;
+import sync.slamtalk.map.mapper.BasketballCourtMapper;
+import sync.slamtalk.map.repository.BasketballCourtRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BasketballCourtService {
+
+    private final BasketballCourtRepository basketballCourtRepository;
+    private final BasketballCourtMapper basketballCourtMapper;
+
+    // 저장된 모든 농구장의 간략 정보
+    public List<BasketballCourtDto> getAllCourtSummaryInfo() {
+        return basketballCourtRepository.findAll().stream()
+                .filter(court -> court.getAdminStatus() == AdminStatus.ACCEPT) // ACCEPT 상태 필터링
+                .map(basketballCourtMapper::toDto) // dto 변환 mapper 호출
+                .collect(Collectors.toList());
+    }
+
+    //특정 농구장 전체 정보
+    public Optional<BasketballCourtDto> getCourtFullInfoById(Long courtId) {
+        return basketballCourtRepository.findById(courtId)
+                .filter(court -> court.getAdminStatus() == AdminStatus.ACCEPT) // ACCEPT 상태 필터링
+                .map(basketballCourtMapper::toFullDto); // dto 변환 mapper 호출
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
-   #13 
- 농구장 entity & dto 생성, 변환 구현
- 마커 띄울 농구장 간략 정보(id,이름,위도,경도) 전달
- 특정 농구장 전체 정보 전달

close #13 