### PR TITLE
#44 채팅리스트 요구사항 서비스,컨트롤러 작성 외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.projectlombok:lombok:1.18.28'
 
     runtimeOnly "com.mysql:mysql-connector-j" // mysql
 	runtimeOnly 'com.h2database:h2' // h2

--- a/src/main/java/sync/slamtalk/chat/config/CustomWebSocketHandler.java
+++ b/src/main/java/sync/slamtalk/chat/config/CustomWebSocketHandler.java
@@ -3,6 +3,7 @@ package sync.slamtalk.chat.config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskRejectedException;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketHandler;
@@ -50,11 +51,12 @@ public class CustomWebSocketHandler extends WebSocketHandlerDecorator {
     public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
         //super.afterConnectionClosed(session,closeStatus);
         log.info("웹 소켓 연결 종료");
-        // TODO 채팅방에 저장된 마지막 메세지 id 저장?
+
+
+
         try{
             super.afterConnectionClosed(session,closeStatus);
             // 여기에 연결 종료 시 필요한 리소스 정리 로직을 추가
-            // TODO USerChatRoom 에 메세지 저장 로직?
         }catch (TaskRejectedException e){
             log.warn("Task was rejected due to server shutdown. Session ID:{}",session.getId());
         }catch (Exception e){

--- a/src/main/java/sync/slamtalk/chat/config/StompErrorHandler.java
+++ b/src/main/java/sync/slamtalk/chat/config/StompErrorHandler.java
@@ -26,11 +26,10 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
         if(ex.getCause().getMessage().equals("Auth")){
             return handleUnauthorizedException(clientMessage,ex);
         }
-
+        // NFR 이 메세지에 포함된 경우
         if(ex.getCause().getMessage().equals("NFR")){
             return handleNotFoundException(clientMessage,ex);
         }
-
         // 기본 에러 메세지 처리
         return super.handleClientMessageProcessingError(clientMessage,ex);
     }

--- a/src/main/java/sync/slamtalk/chat/config/StompWebSocketConfig.java
+++ b/src/main/java/sync/slamtalk/chat/config/StompWebSocketConfig.java
@@ -33,8 +33,8 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
     // 메세지 브로커 기반 통신 설정 -> STOMP Messaging protocol
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setApplicationDestinationPrefixes("/pub");
-        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub"); // "/pub" 가 경로상에 있으면 <<컨트롤러>> 호출
+        registry.enableSimpleBroker("/sub"); // "/subscribe" 가 경로상에 있으면 <<메세지브로커>> 호출
     }
 
 

--- a/src/main/java/sync/slamtalk/chat/controller/ChatController.java
+++ b/src/main/java/sync/slamtalk/chat/controller/ChatController.java
@@ -1,30 +1,87 @@
 package sync.slamtalk.chat.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import sync.slamtalk.chat.dto.ChatErrorResponseCode;
 import sync.slamtalk.chat.dto.Request.ChatCreateDTO;
+import sync.slamtalk.chat.dto.Request.ChatMessageDTO;
+import sync.slamtalk.chat.dto.Response.ChatRoomDTO;
+import sync.slamtalk.chat.entity.UserChatRoom;
 import sync.slamtalk.chat.service.ChatServiceImpl;
+import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.common.BaseException;
+import sync.slamtalk.common.ErrorResponseCode;
+import sync.slamtalk.user.entity.User;
+
+import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
 public class ChatController {
     private final ChatServiceImpl chatService;
 
-
-
-    // TODO : refactor
-
-    // 채팅방 생성 test
-    @PostMapping("/api/create")
-    public String create(@RequestBody ChatCreateDTO dto){
+    // 채팅방 생성
+    @PostMapping("/api/chat/create")
+    @Operation(
+            summary = "채팅방 생성",
+            description = "이 기능은 채팅방을 생성하는 기능입니다.",
+            tags = {"유저","관리자"}
+    )
+    public ApiResponse create(@RequestBody ChatCreateDTO dto){
         long chatRoom = chatService.createChatRoom(dto);
-        return "저장완료" + chatRoom;
-
+        return ApiResponse.ok(); // TODO ApiResponse 수정
     }
+
+
+    // 채팅 리스트
+    // TODO @Param 수정 @AuthenticationPrincipal User user
+    @GetMapping("/api/chat/list")
+    @Operation(
+            summary = "채팅리스트 조회",
+            description = "이 기능은 유저의 채팅리스트를 조회하는 기능입니다.",
+            tags = {"유저"}
+    )
+    public ApiResponse list(){
+        // Test
+        List<ChatRoomDTO> chatLIst = chatService.getChatLIst(1L);
+        return ApiResponse.ok(chatLIst);
+    }
+
+    // 채팅 참여
+    // TODO @Param 수정 @AuthenticationPrincipal User user
+    // TODO 페이징정책 확정되면 다시 수정해야함
+    @PostMapping("/api/chat/participation")
+    @Operation(
+            summary = "과거 내역 전달",
+            description = "이 기능은 채팅방에 입장할 때 채팅방의 과거 내역을 받을 수 있는 기능입니다.",
+            tags = {"유저"}
+    )
+    public ApiResponse participation(@Param("roomId")Long roomId){
+
+        // 채팅방에 속해있는지 검사
+        Optional<UserChatRoom> existUserChatRoom = chatService.isExistUserChatRoom(roomId);
+        if(!existUserChatRoom.isPresent()){
+            System.out.println("없는방");
+            throw new BaseException(ErrorResponseCode.CHAT_FAIL);
+            // TODO ErrorResponse 코드 추가하기 ErrorResponseCode.CHATROOM_NOT_FOUND
+        }
+        // 채팅방에서 주고받았던 메세지 가져오기
+        List<ChatMessageDTO> chatMessage = chatService.getChatMessage(roomId);
+
+        return ApiResponse.ok(chatMessage);
+    }
+
+
+
 
 
 }

--- a/src/main/java/sync/slamtalk/chat/controller/StompChatController.java
+++ b/src/main/java/sync/slamtalk/chat/controller/StompChatController.java
@@ -23,6 +23,7 @@ public class StompChatController {
 
     // "/pub/chat/room" 로 날린 데이터에 대해서
     // "/pub/chat/room/roomId" 로 구독자들에게 해당 메세지 전달
+    // TODO 파라미터로 messageDTO 제거하고 Token 으로 userdb 접근 후 닉네임가져오자
     @MessageMapping(value = "/chat/enter/{roomId}")
     @SendTo("/sub/chat/room/{roomId}")
     public ChatMessageDTO enter(ChatMessageDTO message){
@@ -32,11 +33,10 @@ public class StompChatController {
 
 
     // "/pub/chat/message" 로 날린 데이터에 대해서
-    // "/sub/chat/room/roomId" 로 구독자들에게 해당 message를 전달
+    // "/sub/chat/room/roomId" 로 구독자들에게 해당 message 를 전달
     @MessageMapping("/chat/message/{roomId}")
     @SendTo("/sub/chat/room/{roomId}")
     public ChatMessageDTO message(ChatMessageDTO message){
-        System.out.println(message.getContent());
         return message;
     }
 

--- a/src/main/java/sync/slamtalk/chat/dto/ChatErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/chat/dto/ChatErrorResponseCode.java
@@ -10,7 +10,7 @@ public enum ChatErrorResponseCode implements ResponseCodeDetails {
     // 채팅
     CHAT_FAIL(SC_BAD_REQUEST,4021,"Failed Chatting"),
     CHAT_LIST_NOT_FOUND(SC_NOT_FOUND,4022,"ChatList Not Found"),
-
+    CHAT_ROOM_NOT_FOUND(SC_NOT_FOUND,4023,"ChatRoom Not Found"),
     ;
 
 

--- a/src/main/java/sync/slamtalk/chat/dto/Request/ChatCreateDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Request/ChatCreateDTO.java
@@ -12,5 +12,5 @@ import java.util.List;
 @AllArgsConstructor
 public class ChatCreateDTO implements Serializable {
     private String roomType; // 1:1 이냐 단체방 이냐
-    private String name;
+    private String name; // 채팅방 이름
 }

--- a/src/main/java/sync/slamtalk/chat/dto/Request/ChatMessageDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Request/ChatMessageDTO.java
@@ -1,6 +1,7 @@
 package sync.slamtalk.chat.dto.Request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -13,12 +14,15 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 @Builder(access = AccessLevel.PUBLIC)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChatMessageDTO implements Serializable {
     @Nullable
     private String roomId; // 채팅방 아이디(채팅방 식별자)
     private String senderId; // 메세지를 보낸 사용자의 고유 식별자
+    private String senderNickname; // 메세지를 보낸 사용자의 닉네임 -> 채팅방에 표시될
     @Nullable
     private String content; // 메세지 내용
+    private String messageType; // 메세지 타입 (뒤로가기 : back / 나가기: out) TODO : general 추가
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime timestamp; // 메세지를 보낸 시간
 

--- a/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
@@ -13,10 +13,11 @@ public class ChatRoomDTO implements Serializable {
     private String roomId;
     // 채팅방 이름
     private String name;
-    // 채팅방 마지막 메세지..?
+    // 채팅방 마지막 메세지
     private String last_message;
 
 
+    // 채팅방 마지막 메세지 업데이트
     public void setLast_message(String last_message) {
         this.last_message = last_message;
     }

--- a/src/main/java/sync/slamtalk/chat/entity/Messages.java
+++ b/src/main/java/sync/slamtalk/chat/entity/Messages.java
@@ -10,12 +10,16 @@ import sync.slamtalk.common.BaseEntity;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
-@Table(name = "message")
+@Table(name = "messages")
 public class Messages extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="message_id",nullable = false)
     private Long id; // 식별 아이디
+
+    // 작성자
+    @Column(name = "writer")
+    private String writer;
 
     // 메세지(내용)
     @Column(name = "content")

--- a/src/main/java/sync/slamtalk/chat/entity/UserChatRoom.java
+++ b/src/main/java/sync/slamtalk/chat/entity/UserChatRoom.java
@@ -3,6 +3,7 @@ package sync.slamtalk.chat.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import sync.slamtalk.common.BaseEntity;
+import sync.slamtalk.user.entity.User;
 
 @Entity
 @Getter
@@ -41,6 +42,17 @@ public class UserChatRoom extends BaseEntity {
         }
     }
 
+    // TODO 봉승님 유저로 편의메서드 작성
+    // 생각해보니까 채팅방 리스트가 유저정보에서 관리가 되어야됨(양방향 매핑해야할듯)
+    // 봉승님 코드에서 cascade = CascadeType.ALL, orphanRemoval = true 추가 요청
+    public void setUsers(User user){
+//        this.user = user;
+//        if(!user.getUserChatRooms().contains(this)){
+//            user.getUserChatRooms().add(this);
+//        }
+    }
+
+
     // 채팅방 설정
     public void setChat(ChatRoom chat) {
         this.chat = chat;
@@ -50,6 +62,8 @@ public class UserChatRoom extends BaseEntity {
     }
 
 
-
-
+    // readIndex 값 업데이트하기
+    public void updateReadIndex(Long newReadIndex) {
+        this.readIndex = newReadIndex;
+    }
 }

--- a/src/main/java/sync/slamtalk/chat/entity/UserMock.java
+++ b/src/main/java/sync/slamtalk/chat/entity/UserMock.java
@@ -22,6 +22,7 @@ public class UserMock {
 
 
     // UserChatRoom 추가를 위한 편의 메소드
+    // 굳이 필요 없겠다
     public void addUserChatRoom(UserChatRoom userchatRoom){
         // 사용자채팅방을 모아놓는 set 에 userchatRoom 추가
         userChats.add(userchatRoom);

--- a/src/main/java/sync/slamtalk/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/sync/slamtalk/chat/repository/ChatRoomRepository.java
@@ -10,6 +10,4 @@ import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("SELECT c FROM ChatRoom c JOIN c.userChats uc WHERE uc.user.id=:userId")
-    Optional<ChatRoom> findAllChatRoomsByUserId(@Param("userId")Long UserId);
 }

--- a/src/main/java/sync/slamtalk/chat/repository/MessagesRepository.java
+++ b/src/main/java/sync/slamtalk/chat/repository/MessagesRepository.java
@@ -1,12 +1,13 @@
 package sync.slamtalk.chat.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.repository.query.Param;
 import sync.slamtalk.chat.entity.Messages;
 
-import java.awt.print.Pageable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -14,12 +15,21 @@ import java.util.Set;
 @EnableJpaRepositories
 public interface MessagesRepository extends JpaRepository<Messages,Long> {
 
-    // 특정 roomId 에 해당하는 Message 조회
-     Optional<Messages> findByChatRoomId(Long chatRoomId);
+    // 1. 특정 roomId 에 해당하는 모든 Message 가져오기(과거~최근)
+     List<Messages> findByChatRoomId(Long chatRoomId);
 
 
-    // 특정 채팅방의 가장 최근 메시지를 가져오는 쿼리
+    // 2. 특정 채팅방의 가장 최근 메시지를 가져오기
+    @Query("select m from Messages m where m.chatRoom.id =: chatroom_id order by m.creation_time desc ")
+    Page<Messages> findLatestByChatRoomId(@Param("chatroom_id")Long chatRoomId, Pageable pageable);
 
-    // TODO 특정 keyword 를 포함하고 있는 chat 조회
+
+    // 3. TODO 특정 roomId 에 해당하는 모든 Message 가져오기(최근~과거)
+    // 2번 안되면 여기서 가장 위에거만 가져오면 되긴함
+    @Query("select m from Messages m where m.chatRoom.id=:chatRoomId order by m.creation_time desc")
+    List<Messages> findAllByChatRoom(@Param("chatRoomId")Long chatRoomId);
+
+
+    // TODO 특정 keyword 를 가지고 있는 Message 가져오기
 
 }

--- a/src/main/java/sync/slamtalk/chat/repository/UserMockRepository.java
+++ b/src/main/java/sync/slamtalk/chat/repository/UserMockRepository.java
@@ -1,2 +1,9 @@
-package sync.slamtalk.chat.repository;public interface UserMockRepository {
+package sync.slamtalk.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sync.slamtalk.chat.entity.UserMock;
+
+public interface UserMockRepository extends JpaRepository<UserMock,Long> {
+
+
 }

--- a/src/main/java/sync/slamtalk/chat/repository/UserMockRepository.java
+++ b/src/main/java/sync/slamtalk/chat/repository/UserMockRepository.java
@@ -1,0 +1,2 @@
+package sync.slamtalk.chat.repository;public interface UserMockRepository {
+}

--- a/src/main/java/sync/slamtalk/chat/service/ChatService.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatService.java
@@ -4,6 +4,7 @@ import sync.slamtalk.chat.dto.Request.ChatCreateDTO;
 import sync.slamtalk.chat.dto.Request.ChatMessageDTO;
 import sync.slamtalk.chat.dto.Response.ChatRoomDTO;
 import sync.slamtalk.chat.entity.ChatRoom;
+import sync.slamtalk.chat.entity.Messages;
 import sync.slamtalk.chat.entity.UserChatRoom;
 
 import java.util.List;
@@ -12,13 +13,15 @@ import java.util.Optional;
 public interface ChatService {
 
 
-    // 채팅방 생성하기
+    // 채팅방 생성
     long createChatRoom(ChatCreateDTO chatCreateDTO);
 
-    // 채팅방에 유저 넣어주기
-    void addMembers(Long ChatRoomId);
 
-    // 메세지 저장하기
+    // 채팅방에 유저 추가
+    void setUserChatRoom(Long ChatRoomId);
+
+
+    // 메세지 저장
     void saveMessage(ChatMessageDTO chatMessageDTO);
 
 
@@ -26,15 +29,27 @@ public interface ChatService {
     Optional<ChatRoom> isExistChatRoom(Long ChatRoomId);
 
 
-    // 사용자 채팅방에 있는 채팅방인지 확인(구독여부 확인하는)
+    // 사용자 채팅방에 있는 채팅방인지 확인(구독여부 확인)
     Optional<UserChatRoom> isExistUserChatRoom(Long ChatRoomId);
 
 
-    // 특정 방에서 주고받은 모든 메세지 가져오기
+    // 채팅방 나갈때 readIndex 저장
+    void saveReadIndex(Long userId,Long chatRoomId,Long readIndex);
+
+
+    // 특정 방에서 주고 받은 모든 메세지 가져오기
+    // 페이징 방식에 의존
+    //      1. 사용자가 입장한 시점의 채팅방 메세지부터 모두 내려주기
+    //      2. 사용자가 마지막으로 읽은 메세지 이후부터 내려주기
     List<ChatMessageDTO> getChatMessage(Long chatRoomId);
 
-    // 채팅리스트 가져오기
+
+    // 사용자 채팅리스트 가져오기
     List<ChatRoomDTO> getChatLIst(Long userId);
+
+
+    // 특정방의 가장 마지막 메세지 가져오기
+    Messages getLastMessageFromChatRoom(Long chatRoomId);
 
 
 

--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -2,22 +2,25 @@ package sync.slamtalk.chat.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sync.slamtalk.chat.dto.ChatErrorResponseCode;
 import sync.slamtalk.chat.dto.Request.ChatCreateDTO;
 import sync.slamtalk.chat.dto.Request.ChatMessageDTO;
 import sync.slamtalk.chat.dto.Response.ChatRoomDTO;
-import sync.slamtalk.chat.entity.ChatRoom;
-import sync.slamtalk.chat.entity.Messages;
-import sync.slamtalk.chat.entity.RoomType;
-import sync.slamtalk.chat.entity.UserChatRoom;
+import sync.slamtalk.chat.entity.*;
 import sync.slamtalk.chat.repository.ChatRoomRepository;
 import sync.slamtalk.chat.repository.MessagesRepository;
 import sync.slamtalk.chat.repository.UserChatRoomRepository;
+import sync.slamtalk.chat.repository.UserMockRepository;
 import sync.slamtalk.common.BaseException;
+import sync.slamtalk.common.ErrorResponseCode;
 
+import java.awt.print.Pageable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,6 +32,7 @@ public class ChatServiceImpl implements ChatService{
     private final ChatRoomRepository chatRoomRepository;
     private final MessagesRepository messagesRepository;
     private final UserChatRoomRepository userChatRoomRepository;
+    private final UserMockRepository userMockRepository;
 
     // 채팅방 생성(농구장:미리해놓기, 그외 모두 SUBSCRIBE 시에)
     @Override
@@ -45,25 +49,33 @@ public class ChatServiceImpl implements ChatService{
 
     // 채팅방 입장(STOMP: SUBSCRIBE) ❗️최초 입장일때만 ==> Token 완료 시 테스트해야함
     @Override
-    public void addMembers(Long chatRoomId) {
-        // add member to chatRoom
+    public void setUserChatRoom(Long chatRoomId) {
+        // chatRoomId 로 ChatRoom 가져오기
         Optional<ChatRoom> chatroom = chatRoomRepository.findById(chatRoomId);
-        if(chatroom.isPresent()){ // chatRoom 이 존재하면
-            ChatRoom chatRoom = chatroom.get();
-            // userChatRoom setting
-            UserChatRoom userChatRoom = UserChatRoom.builder()
-                    //.user() // token
-                    .chat(chatRoom)
-                    .readIndex(0L)
-                    .build();
-            // chatRoom add userChatRoom
-            chatRoom.addUserChatRoom(userChatRoom);
-            // userChatRoom save
-            userChatRoomRepository.save(userChatRoom);
-        }else {
-            // Exception 처리
-            log.info("Exception");
+
+        // Test : user
+        Optional<UserMock> userMock = userMockRepository.findById(1L);
+
+        // 만약 userchatRoom 에 해당 chatRoom 이 존재하지 않는다면
+        List<UserChatRoom> userChatList = userChatRoomRepository.findByUser_Id(1L);
+        for(UserChatRoom ucr: userChatList){
+            //userchatRoom 중 입장한 chatRoomId 와 일치한다면
+            if(ucr.getId().equals(chatRoomId)){
+                return; // 이미 userchatRoom 에 있으니 새로 넣어줄 필요 없음
+            }
         }
+        // userChatRoom에 없다면 새로 생성해주기
+        UserChatRoom userChatRoom = UserChatRoom.builder()
+                .user(userMock.get())
+                .chat(chatroom.get())
+                .readIndex(0L)// 초기값 0
+                .build();
+        // UserchatRoom 저장하고
+        userChatRoomRepository.save(userChatRoom);
+
+        // ChatRoom 에도 userchatRoom 추가
+        ChatRoom chatRoom = chatroom.get();
+        chatRoom.addUserChatRoom(userChatRoom);
     }
 
 
@@ -77,12 +89,14 @@ public class ChatServiceImpl implements ChatService{
             // Message create
             Messages messages = Messages.builder()
                     .chatRoom(Room)
+                    .writer(chatMessageDTO.getSenderId())
                     .content(chatMessageDTO.getContent())
                     .creation_time(chatMessageDTO.getTimestamp().toString())
                     .build();
             messagesRepository.save(messages);
         }else{
             // TODO Exceptioin 처리
+            throw new BaseException(ErrorResponseCode.CHAT_FAIL);
         }
     }
 
@@ -107,6 +121,7 @@ public class ChatServiceImpl implements ChatService{
         return Optional.empty();
     }
 
+
     // 채팅리스트 가져오기 ==> Token 완료 시 테스트해야함
     @Override
     public List<ChatRoomDTO> getChatLIst(Long userId) {
@@ -125,21 +140,66 @@ public class ChatServiceImpl implements ChatService{
                     .name(ucr.getChat().getName())
                     .build();
 
-            Optional<Messages> chatContent = messagesRepository.findByChatRoomId(ucr.getId());
-            if(chatContent.isPresent()){
-                chatRoomDTO.setLast_message(chatContent.get().toString());
-            }
+            List<Messages> chatContent = messagesRepository.findByChatRoomId(ucr.getId());
+
+            chatRoomDTO.setLast_message(chatContent.get(0).getContent());
+
             AnsList.add(chatRoomDTO);
         }
         return AnsList;
     }
 
 
-    // TODO 채팅 내역 가져 오기
+    // TODO 특정 방에서 주고받은 모든 메세지 가져오기
     @Override
     public List<ChatMessageDTO> getChatMessage(Long chatRoomId) {
-        return null;
+        List<ChatMessageDTO> ansList = new ArrayList<>();
+        List<Messages> byChatRoomId = messagesRepository.findByChatRoomId(chatRoomId);
+
+        // messageRepository 에서 가져온 메세지로 dto 생성하기
+        for(Messages m : byChatRoomId){
+            ChatMessageDTO messageDTO = ChatMessageDTO.builder()
+                    .roomId(m.getChatRoom().getId().toString())
+                    .senderId(m.getWriter())
+                    .content(m.getContent())
+                    .build();
+            ansList.add(messageDTO);
+        }
+        return ansList;
     }
+
+
+
+    // 특정 chatRoom id 로 저장된 메세지 중 가장 마지막 메세지 가져옴
+    @Override
+    public Messages getLastMessageFromChatRoom(Long chatRoomId) {
+
+        List<Messages> allByChatRoom = messagesRepository.findAllByChatRoom(chatRoomId);
+        return allByChatRoom.get(0);
+    }
+
+    // userChatRoom 에 readIndex 저장하기
+    @Override
+    public void saveReadIndex(Long userId,Long chatRoomId,Long readIndex) {
+
+        // userchatRoomRepository 에서 userId 검색해서 chatRoom ( user가 참여한 chatRoomList 를 가져옴 )
+        List<UserChatRoom> userChatRooms = userChatRoomRepository.findByUser_Id(userId);
+
+
+        // 가져온 userChatRoomList 에서 해당하는 chatRoomId 를 가진 userchatRoom 를 가져온다
+        Optional<UserChatRoom> matchingChatRoom = userChatRooms.stream()
+                .filter(userChatRoom -> userChatRoom.getChat().getId().equals(chatRoomId))
+                .findFirst();
+
+        // 해당하는 userchatRoom 의 readIndex 에 readIndex 를 업데이트
+        if(matchingChatRoom.isPresent()){
+            UserChatRoom userChatRoom = matchingChatRoom.get();
+            userChatRoom.updateReadIndex(readIndex);
+        }
+
+    }
+
+
 
 
     // ChatRoom 타입
@@ -166,9 +226,6 @@ public class ChatServiceImpl implements ChatService{
         // 1:1, 농구장, 팀매칭 -> 이름 하나
         return dto.getName();
     }
-
-
-
 
 
 

--- a/src/test/java/sync/slamtalk/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/sync/slamtalk/chat/repository/ChatRoomRepositoryTest.java
@@ -1,4 +1,27 @@
+package sync.slamtalk.chat.repository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import sync.slamtalk.chat.entity.ChatRoom;
+import sync.slamtalk.chat.entity.RoomType;
+import sync.slamtalk.chat.entity.UserChatRoom;
+import sync.slamtalk.chat.entity.UserMock;
+
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
 class ChatRoomRepositoryTest {
-  
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
 }

--- a/src/test/java/sync/slamtalk/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/sync/slamtalk/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class ChatRoomRepositoryTest {
+  
+}

--- a/src/test/java/sync/slamtalk/chat/repository/MessagesRepositoryTest.java
+++ b/src/test/java/sync/slamtalk/chat/repository/MessagesRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MessagesRepositoryTest {
+  
+}

--- a/src/test/java/sync/slamtalk/chat/repository/MessagesRepositoryTest.java
+++ b/src/test/java/sync/slamtalk/chat/repository/MessagesRepositoryTest.java
@@ -1,4 +1,169 @@
+package sync.slamtalk.chat.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import sync.slamtalk.chat.entity.ChatRoom;
+import sync.slamtalk.chat.entity.Messages;
+import sync.slamtalk.chat.entity.RoomType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@Slf4j
 class MessagesRepositoryTest {
-  
+
+    @Autowired
+    private MessagesRepository messagesRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+
+    @Test
+    void findByChatRoomId() {
+        // 테스트 데이터 생성
+        ChatRoom chatRoom = ChatRoom.builder()
+                .name("TEST ROOM")
+                .roomType(RoomType.TOGETHER)
+                .build();
+
+        // 테스트 데이터 저장
+        entityManager.persist(chatRoom);
+
+        Messages messages1 = Messages.builder()
+                .chatRoom(chatRoom)
+                .content("안녕ㅎㅎ")
+                .creation_time(LocalDateTime.now().toString())
+                .build();
+        entityManager.persist(messages1);
+
+        Messages messages2 = Messages.builder()
+                .chatRoom(chatRoom)
+                .content("반가워")
+                .creation_time(LocalDateTime.now().toString())
+                                        .build();
+        entityManager.persist(messages2);
+
+        Optional<ChatRoom> chatroom = chatRoomRepository.findById(chatRoom.getId());
+
+        Assertions.assertThat(chatroom).isPresent();
+        Assertions.assertThat(chatroom.get()).isEqualTo(chatRoom);
+
+    }
+
+    @Test
+    void findLatestByChatRoomId() {
+        //test 데이터 생성
+        ChatRoom chatRoomBasket = ChatRoom.builder()
+                .roomType(RoomType.BASKETBALL)
+                .name("농구장채팅")
+                .build();
+        ChatRoom chatRoomTogether = ChatRoom.builder()
+                .roomType(RoomType.TOGETHER)
+                .name("같이하기")
+                .build();
+        ChatRoom chatRoomDirect = ChatRoom.builder()
+                .roomType(RoomType.DIRECT)
+                .name("일대일")
+                .build();
+        //EntityManager 저장
+        entityManager.persist(chatRoomBasket);
+        entityManager.persist(chatRoomTogether);
+        entityManager.persist(chatRoomDirect);
+
+
+        //test 데이터 생성
+        Messages messages1 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomBasket)
+                .content("농구하자~")
+                .build();
+
+        Messages messages2 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomBasket)
+                .content("그래 몇시에 만나~")
+                .build();
+        Messages messages3 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomDirect)
+                .content("안녕하세요 유저입니다")
+                .build();
+        Messages messages4 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomDirect)
+                .content("안녕하세요 처음 뵙겠습니다")
+                .build();
+        Messages messages5 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomDirect)
+                .content("ㅋㅋㅋㅋ하이욤")
+                .build();
+        Messages messages6 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomBasket)
+                .content("4시쯤 어때?")
+                .build();
+        Messages messages7 = Messages.builder()
+                .creation_time(LocalDateTime.now().toString())
+                .chatRoom(chatRoomBasket)
+                .content("좋지좋지~~!")
+                .build();
+        //EntityManager 저장
+        entityManager.persist(messages1);
+        entityManager.persist(messages2);
+        entityManager.persist(messages3);
+        entityManager.persist(messages4);
+        entityManager.persist(messages5);
+        entityManager.persist(messages6);
+        entityManager.persist(messages7);
+
+
+        //검증
+        // 테스트할 채팅방의 ID
+//        Long chatRoomId = chatRoomBasket.getId();
+//
+//        // PageRequest 생성 (첫 번째 페이지, 페이지 당 한 개의 요소)
+//        Pageable pageable = PageRequest.of(0, 1);
+//
+//        // 가장 최근 메시지 가져오기
+//        Page<Messages> latestMessagePage = messagesRepository.findLatestByChatRoomId(chatRoomId, pageable);
+//
+//        // 결과 검증
+//        assertFalse(latestMessagePage.isEmpty(), "결과가 비어있지 않아야 합니다.");
+//        assertEquals(1, latestMessagePage.getContent().size(), "정확히 하나의 메시지가 있어야 합니다.");
+
+        // 내림차순(가장최근꺼부터 출력)
+        List<Messages> allByChatRoom = messagesRepository.findAllByChatRoom(chatRoomBasket.getId());
+
+        // 오름차순(가장오래된거부터 출력)
+        List<Messages> byChatRoomId = messagesRepository.findByChatRoomId(chatRoomBasket.getId());
+
+        Messages messages = allByChatRoom.get(0);
+        assertTrue(messages.getId().equals(messages7.getId()));
+
+        for(Messages m : allByChatRoom){
+            System.out.println(m.getContent()+m.getCreation_time());
+        }
+
+
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 채팅방 id를 통해 다시 채팅방에 접속하는 로직 추가 -> STOMP 메세지를 보내면 되는거였음, 대신 입장 시 사용될 채팅방 컨트롤러 추가함(아래내용에포함)
- 채팅방 생성, 유저의 채팅리스트 조회, 채팅방 과거 내역 조회 컨트롤러 수정 및 추가
- 채팅방 유효성 확인(존재여부,사용자가참여한채팅방여부) 서비스 추가
- 채팅방 채팅 내역 조회, 채팅리스트 내역 조회 서비스 추가
- 채팅방 뒤로 가기 시 마지막 메세지 아이디 저장
- STOMP MESSAGE FRAME DISCONNECT 로직 추가(POSTMAN)


## 💬 리뷰 요구사항 (선택)
- 👀 참고해주세요
- ‼️ 📢 userMock 은 이번 pr merge 후에 완전히 삭제할 예정입니다(user_mock -> user Entity 로 변경)
- ‼️ 📢 test 코드 추가로 build.gradle 수정 사항이 발생했습니다.
- ‼️ 📢 기능 방향에 대해 논의중인것들이 있어서 TODO(아직 미완성 혹은 작성안함) 와 주석 등 코드가 지저분 합니다. 
   이부분은 추후 리팩토링 할 예정입니다.


resolved #44 