### PR TITLE
#47 메이트 찾기,신청자 목록 관련 리팩토링 및 기능 추가

### DIFF
--- a/src/main/java/sync/slamtalk/mate/controller/MatePostController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/MatePostController.java
@@ -38,8 +38,6 @@ public class MatePostController {
 
         // MateFormDTO를 MatePost로 변환한다.
         MatePost matePost = mateFormDTO.toEntity(userId);
-
-        // MatePost를 저장한다.
         long matePostId = matePostService.registerMatePost(matePost);
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create("/api/mate/" + matePostId));
@@ -52,7 +50,7 @@ public class MatePostController {
             tags = {"메이트 찾기"}
     )
     @GetMapping("/{matePostId}")
-    public ApiResponse<MateFormDTO> getMatePost(long matePostId){
+    public ApiResponse<MateFormDTO> getMatePost(@PathVariable("matePostId") long matePostId){
         MateFormDTO dto = matePostService.getMatePost(matePostId);
         return ApiResponse.ok(dto);
     }
@@ -63,7 +61,7 @@ public class MatePostController {
             tags = {"메이트 찾기"}
     )
     @PatchMapping("/{matePostId}")
-    public ApiResponse<MateFormDTO> updateMatePost(@PathVariable long matePostId, @RequestBody MateFormDTO mateFormDTO){
+    public ApiResponse<MateFormDTO> updateMatePost(@PathVariable("matePostId") long matePostId, @RequestBody MateFormDTO mateFormDTO){
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         int userId = 1;
 
@@ -82,7 +80,7 @@ public class MatePostController {
             tags = {"메이트 찾기"}
     )
     @DeleteMapping("/{matePostId}")
-    public ApiResponse<MateFormDTO> deleteMatePost(@PathVariable long matePostId){
+    public ApiResponse<MateFormDTO> deleteMatePost(@PathVariable("matePostId") long matePostId){
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         int userId = 1;
 

--- a/src/main/java/sync/slamtalk/mate/controller/MatePostController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/MatePostController.java
@@ -3,17 +3,22 @@ package sync.slamtalk.mate.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.mate.dto.MateFormDTO;
 import sync.slamtalk.mate.entity.MatePost;
 import sync.slamtalk.mate.service.MatePostService;
 
+import java.net.URI;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/mate")
 @RequiredArgsConstructor
-public class MatepostController {
+public class MatePostController {
 
     private final MatePostService matePostService;
 
@@ -23,7 +28,7 @@ public class MatepostController {
             tags = {"메이트 찾기"}
     )
     @PostMapping("/register")
-    public ApiResponse registerMatePost(@RequestBody MateFormDTO mateFormDTO){
+    public ResponseEntity registerMatePost(@RequestBody MateFormDTO mateFormDTO){
 
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         int userId = 1;
@@ -31,13 +36,14 @@ public class MatepostController {
         // * 해당 게시글 등록 폼에 입력된 작성자 ID와 접속자 ID가 일치하는지 확인한다.
 
 
-        // * MateFormDTO를 MatePost로 변환한다.
+        // MateFormDTO를 MatePost로 변환한다.
         MatePost matePost = mateFormDTO.toEntity(userId);
 
-        // * MatePost를 저장한다.
-        matePostService.registerMatePost(matePost);
-
-        return ApiResponse.ok();
+        // MatePost를 저장한다.
+        long matePostId = matePostService.registerMatePost(matePost);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("/api/mate/" + matePostId));
+        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
     }
 
     @Operation(
@@ -87,26 +93,8 @@ public class MatepostController {
         matePostService.deleteMatePost(matePostId);
         return ApiResponse.ok();
     }
-    //
-//    @Operation(
-//            summary = "메이트 찾기 글에 참여하기",
-//            description = "글 아이디와 참여자 정보를 요청하면 글에 참여하는 api 입니다.",
-//            tags = {"메이트 찾기"}
-//    )
-//    @PostMapping("/{matePostId}/participant")
-//    public ApiResponse<MateFormDTO> addParticipant(long matePostId, MateFormDTO mateFormDTO){
-//        // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
-//        int userId = 1;
-//        String userNickname = "테스트";
-//
-//        // * MateFormDTO를 MatePost로 변환한다.
-//        MatePost matePost = mateFormDTO.toEntity(userId, userNickname);
-//
-//        // * MatePost에 참여자를 추가한다.
-//        MatePostService.addParticipant(matePostId, matePost.getParticipants().get(0));
-//
-//        return ApiResponse.ok();
-//    }
+
+
     @GetMapping("/test")
     public ApiResponse<MateFormDTO> test(){
         return ApiResponse.ok();

--- a/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
@@ -24,13 +24,11 @@ public class ParticipantController {
             tags = {"메이트 찾기 / 참여자 목록"}
     )
     @PostMapping("/{matePostId}/participants/register")
-    public ApiResponse<MatePostApplicantDTO> addParticipant(@PathVariable long matePostId, @RequestBody MatePostApplicantDTO matePostApplicantDTO){
+    public ApiResponse<MatePostApplicantDTO> addParticipant(@PathVariable("matePostId") long matePostId, @RequestBody MatePostApplicantDTO matePostApplicantDTO){
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         long userId = 1;
         String userNickname = "testApplicant";
-        if(matePostApplicantDTO.getApplyStatus() != ApplyStatusType.WAITING){
-            return ApiResponse.fail(MateErrorResponseCode.PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS);
-        }
+
         // * 해당 글에 지원자의 신청 절차를 진행한다.
         MatePostApplicantDTO dto = participantService.addParticipant(matePostId, userId, userNickname, matePostApplicantDTO);
 
@@ -43,7 +41,7 @@ public class ParticipantController {
             tags = {"메이트 찾기 / 참여자 목록"}
     )
     @PatchMapping("/{matePostId}/participants/{participantTableId}")
-    public ApiResponse updateParticipant(@PathVariable long matePostId, @PathVariable long participantTableId, @RequestParam ApplyStatusType applyStatus){
+    public ApiResponse updateParticipant(@PathVariable("matePostId") long matePostId, @PathVariable("participantTableId") long participantTableId, @RequestParam("applyStatus") ApplyStatusType applyStatus){
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         long id = 1;
 
@@ -66,7 +64,7 @@ public class ParticipantController {
     )
     @GetMapping("/{matePostId}/participants")
     // todo : 프론트엔드에서 호출 할 경우가 없다면 삭제한다.
-    public ApiResponse<List<MatePostApplicantDTO>> getParticipants(@PathVariable long matePostId){
+    public ApiResponse<List<MatePostApplicantDTO>> getParticipants(@PathVariable("matePostId") long matePostId){
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         long userId = 1;
 

--- a/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
@@ -1,0 +1,79 @@
+package sync.slamtalk.mate.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.mate.dto.MatePostApplicantDTO;
+import sync.slamtalk.mate.entity.ApplyStatusType;
+import sync.slamtalk.mate.error.UserErrorResponseCode;
+import sync.slamtalk.mate.service.ParticipantService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/mate")
+@RequiredArgsConstructor
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    @Operation(
+            summary = "메이트 찾기 글에 참여하기",
+            description = "글 아이디와 참여자 정보를 요청하면 글에 참여하는 api 입니다.",
+            tags = {"메이트 찾기 / 참여자 목록"}
+    )
+    @PostMapping("/{matePostId}/participants/register")
+    public ApiResponse<MatePostApplicantDTO> addParticipant(@PathVariable long matePostId, @RequestBody MatePostApplicantDTO matePostApplicantDTO){
+        // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
+        long userId = 1;
+        String userNickname = "testApplicant";
+        if(matePostApplicantDTO.getApplyStatus() != ApplyStatusType.WAITING){
+            return ApiResponse.fail(UserErrorResponseCode.PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS);
+        }
+        // * 해당 글에 지원자의 신청 절차를 진행한다.
+        MatePostApplicantDTO dto = participantService.addParticipant(matePostId, userId, userNickname, matePostApplicantDTO);
+
+        return ApiResponse.ok(dto);
+    }
+
+    @Operation(
+            summary = "메이트 찾기 글에 참여자 상태 변경(수락, 거절, 취소)",
+            description = "글 아이디와 참여자 아이디, 변경할 상태를 요청하면 글에 참여자 상태를 변경하는 api 입니다.",
+            tags = {"메이트 찾기 / 참여자 목록"}
+    )
+    @PatchMapping("/{matePostId}/participants/{participantTableId}")
+    public ApiResponse updateParticipant(@PathVariable long matePostId, @PathVariable long participantTableId, @RequestParam ApplyStatusType applyStatus){
+        // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
+        long id = 1;
+
+        if(applyStatus == ApplyStatusType.ACCEPTED){
+            return participantService.acceptParticipant(matePostId, participantTableId, id);
+        }else if(applyStatus == ApplyStatusType.REJECTED){
+            return participantService.rejectParticipant(matePostId, participantTableId, id);
+        }else if(applyStatus == ApplyStatusType.CANCEL){
+            return participantService.cancelParticipant(matePostId, participantTableId, id);
+        }else{
+            return ApiResponse.fail("잘못된 요청입니다.");
+        }
+
+    }
+
+    @Operation(
+            summary = "메이트 찾기 글에 참여자 목록 조회",
+            description = "글 아이디를 요청하면 해당 글에 참여한 참여자 목록을 조회하는 api 입니다.",
+            tags = {"메이트 찾기 / 참여자 목록"}
+    )
+    @GetMapping("/{matePostId}/participants")
+    // todo : 프론트엔드에서 호출 할 경우가 없다면 삭제한다.
+    public ApiResponse<List<MatePostApplicantDTO>> getParticipants(@PathVariable long matePostId){
+        // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
+        long userId = 1;
+
+        // * 해당 글에 지원자의 신청 절차를 진행한다.
+        List<MatePostApplicantDTO> dto = participantService.getParticipants(matePostId);
+
+        return ApiResponse.ok(dto);
+    }
+
+}

--- a/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.mate.dto.MatePostApplicantDTO;
 import sync.slamtalk.mate.entity.ApplyStatusType;
-import sync.slamtalk.mate.error.UserErrorResponseCode;
+import sync.slamtalk.mate.error.MateErrorResponseCode;
 import sync.slamtalk.mate.service.ParticipantService;
 
 import java.util.List;
@@ -29,7 +29,7 @@ public class ParticipantController {
         long userId = 1;
         String userNickname = "testApplicant";
         if(matePostApplicantDTO.getApplyStatus() != ApplyStatusType.WAITING){
-            return ApiResponse.fail(UserErrorResponseCode.PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS);
+            return ApiResponse.fail(MateErrorResponseCode.PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS);
         }
         // * 해당 글에 지원자의 신청 절차를 진행한다.
         MatePostApplicantDTO dto = participantService.addParticipant(matePostId, userId, userNickname, matePostApplicantDTO);

--- a/src/main/java/sync/slamtalk/mate/dto/MateFormDTO.java
+++ b/src/main/java/sync/slamtalk/mate/dto/MateFormDTO.java
@@ -3,9 +3,11 @@ package sync.slamtalk.mate.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.*;
 import sync.slamtalk.mate.entity.MatePost;
-import sync.slamtalk.mate.entity.Participant;
+import sync.slamtalk.mate.entity.RecruitedSkillLevelType;
 import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.mate.entity.SkillLevelType;
 
@@ -20,16 +22,19 @@ import java.util.List;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MateFormDTO {
-    @NonNull
-    private long userId; // 글 작성자 아이디 // * User 테이블과 매핑 필요
     private long matePostId; // 글 아이디
+    private long writerId; // 작성자 아이디
 
     private String title; // 제목
     private String content; // 본문
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    private LocalDateTime scheduledTime; // 예정된 시간
+    private LocalDateTime startScheduledTime; // 예정된 시작 시간
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime endScheduledTime; // 예정된 종료 시간
     private String locationDetail; // 상세 시합 장소
-    private SkillLevelType skillLevel; // 원하는 스킬 레벨 "BEGINNER", "INTERMEDIATE", "MASTER", "IRRELEVANT"
+    @Enumerated(EnumType.STRING)
+    private RecruitedSkillLevelType skillLevel; // 원하는 스킬 레벨 - BEGINNER, OVER_BEGINNER, UNDER_LOW, OVER_LOW, UNDER_MIDDLE, OVER_MIDDLE, UNDER_HIGH, HIGH
+    private List<SkillLevelType> skillLevelList; // 원하는 스킬 레벨 목록 (프론트로 응답 시에만 사용)
 
     private int maxParticipantsCenters; // 모집 포지션 센터 최대 인원 수
     private int currentParticipantsCenters; // 모집 포지션 센터 현재 인원 수
@@ -43,23 +48,28 @@ public class MateFormDTO {
     private int maxParticipantsOthers; // 모집 포지션 무관 최대 인원 수
     private int currentParticipantsOthers; // 모집 포지션 무관 현재 인원 수
 
-    private List<Participant> participants = new ArrayList<>(); // 참여자 목록
+    private List<MatePostApplicantDTO> participants = new ArrayList<>(); // 참여자 목록
 
     @JsonIgnore
-    public MatePost toEntity(long writerId) {
+    public MatePost toEntity(long userId) { // * writerId를 User 객체로 대체할 것!
             return MatePost.builder()
-                    .writerId(writerId)
+                    .writerId(userId)
                     .title(title)
-                    .scheduledTime(scheduledTime)
+                    .startScheduledTime(startScheduledTime)
+                    .endScheduledTime(endScheduledTime)
                     .locationDetail(locationDetail)
                     .content(content)
                     .maxParticipantsCenters(maxParticipantsCenters)
+                    .currentParticipantsCenters(0)
                     .maxParticipantsGuards(maxParticipantsGuards)
+                    .currentParticipantsGuards(0)
                     .maxParticipantsForwards(maxParticipantsForwards)
+                    .currentParticipantsForwards(0)
                     .maxParticipantsOthers(maxParticipantsOthers)
+                    .currentParticipantsOthers(0)
                     .skillLevel(skillLevel)
-                    .softDelete(false)
                     .recruitmentStatus(RecruitmentStatusType.RECRUITING)
+                    .participants(new ArrayList<>())
                     .build();
     }
 

--- a/src/main/java/sync/slamtalk/mate/dto/MatePostApplicantDTO.java
+++ b/src/main/java/sync/slamtalk/mate/dto/MatePostApplicantDTO.java
@@ -1,0 +1,41 @@
+package sync.slamtalk.mate.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import lombok.*;
+import sync.slamtalk.mate.entity.ApplyStatusType;
+import sync.slamtalk.mate.entity.PositionType;
+import sync.slamtalk.mate.entity.SkillLevelType;
+
+@NoArgsConstructor
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Valid
+public class MatePostApplicantDTO {
+
+    private long participantTableId;
+    private String participantNickname;
+    private ApplyStatusType applyStatus;
+    private PositionType position;
+    private SkillLevelType skillLevel;
+
+    public MatePostApplicantDTO(long participantTableId, ApplyStatusType applyStatus) {
+        this.participantTableId = participantTableId;
+        this.applyStatus = applyStatus;
+    }
+
+    public MatePostApplicantDTO(PositionType position, SkillLevelType skillLevel) {
+        this.skillLevel = skillLevel;
+        this.position = position;
+        this.applyStatus = applyStatus;
+    }
+
+    public MatePostApplicantDTO(long participantTableId, String participantNickname, PositionType position, SkillLevelType skillLevel, ApplyStatusType applyStatus) {
+        this.participantTableId = participantTableId;
+        this.participantNickname = participantNickname;
+        this.position = position;
+        this.skillLevel = skillLevel;
+        this.applyStatus = applyStatus;
+    }
+}

--- a/src/main/java/sync/slamtalk/mate/entity/MatePost.java
+++ b/src/main/java/sync/slamtalk/mate/entity/MatePost.java
@@ -5,12 +5,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.common.BaseEntity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static sync.slamtalk.mate.error.MateErrorResponseCode.DECREASE_POSITION_NOT_AVAILABLE;
+import static sync.slamtalk.mate.error.MateErrorResponseCode.INCREASE_POSITION_NOT_AVAILABLE;
 
 @Entity
 @Getter
@@ -181,74 +185,79 @@ public class MatePost extends BaseEntity {
                 this.currentParticipantsOthers = currentParticipantsOthers;
         }
 
-        public boolean increasePositionNumbers(PositionType position){
+        public ApiResponse increasePositionNumbers(PositionType position){
                 switch(position){
                         case CENTER:
                                 if(getCurrentParticipantsCenters() >= getMaxParticipantsCenters()){
-                                        throw new IllegalArgumentException("센터 참여 인원이 모두 찼습니다.");
+                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsCenters(getCurrentParticipantsCenters() + 1);
                                 }
                                 break;
                         case GUARD:
                                 if(getCurrentParticipantsGuards() >= getMaxParticipantsGuards()){
-                                        throw new IllegalArgumentException("가드 참여 인원이 모두 찼습니다.");
+                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsGuards(getCurrentParticipantsGuards() + 1);
                                 }
                                 break;
                         case FORWARD:
                                 if(getCurrentParticipantsForwards() >= getMaxParticipantsForwards()){
-                                        throw new IllegalArgumentException("포워드 참여 인원이 모두 찼습니다.");
+                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsForwards(getCurrentParticipantsForwards() + 1);
                                 }
                                 break;
                         case UNSPECIFIED:
                                 if(getCurrentParticipantsOthers() >= getMaxParticipantsOthers()){
-                                        throw new IllegalArgumentException("모집 포지션 무관 참여 인원이 모두 찼습니다.");
+                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsOthers(getCurrentParticipantsOthers() + 1);
                                 }
                                 break;
                 }
-                return true;
+                return ApiResponse.ok("성공적으로 인원을 늘렸습니다.");
         }
 
 
-        public boolean reducePositionNumbers(PositionType position){
+        public ApiResponse reducePositionNumbers(PositionType position){
                 switch(position){
                         case CENTER:
                                 if(getCurrentParticipantsCenters() == 0){
-                                        throw new IllegalArgumentException("더 이상 센터 인원을 줄일 수 없습니다.");
+                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsCenters(getCurrentParticipantsCenters() - 1);
                                 }
                                 break;
                         case GUARD:
                                 if(getCurrentParticipantsGuards() == 0){
-                                        throw new IllegalArgumentException("더 이상 가드 인원을 줄일 수 없습니다.");
+                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsGuards(getCurrentParticipantsGuards() - 1);
                                 }
                                 break;
                         case FORWARD:
                                 if(getCurrentParticipantsForwards() == 0){
-                                        throw new IllegalArgumentException("더 이상 포워드 인원을 줄일 수 없습니다.");
+                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsForwards(getCurrentParticipantsForwards() - 1);
                                 }
                                 break;
                         case UNSPECIFIED:
                                 if(getCurrentParticipantsOthers() == 0){
-                                        throw new IllegalArgumentException("더 이상 모집 포지션 무관 인원을 줄일 수 없습니다.");
+                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsOthers(getCurrentParticipantsOthers() - 1);
                                 }
                                 break;
                 }
-                return true;
+                return ApiResponse.ok("성공적으로 인원을 줄였습니다.");
         }
+
+        // todo : 참여자 목록의 최대 포지션 인원을 조정할 때 현재 인원보다 낮게 조정하지 못하도록 하는 기능 구현 필요
+        // todo : 참여자 목록의 최대 포지션 인원을 일정 수치 이상 올리지 못하도록 하는 기능 구현 필요
+
+        // todo : 해당 모집 글의 요구 실력에 미달하거나 초과할 경우 참여자 목록에 추가하지 못하도록 하는 기능 구현 필요
 
         @Override
         public boolean equals(Object o) {

--- a/src/main/java/sync/slamtalk/mate/entity/MatePost.java
+++ b/src/main/java/sync/slamtalk/mate/entity/MatePost.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.common.BaseEntity;
+import sync.slamtalk.common.BaseException;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -189,28 +190,28 @@ public class MatePost extends BaseEntity {
                 switch(position){
                         case CENTER:
                                 if(getCurrentParticipantsCenters() >= getMaxParticipantsCenters()){
-                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsCenters(getCurrentParticipantsCenters() + 1);
                                 }
                                 break;
                         case GUARD:
                                 if(getCurrentParticipantsGuards() >= getMaxParticipantsGuards()){
-                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsGuards(getCurrentParticipantsGuards() + 1);
                                 }
                                 break;
                         case FORWARD:
                                 if(getCurrentParticipantsForwards() >= getMaxParticipantsForwards()){
-                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsForwards(getCurrentParticipantsForwards() + 1);
                                 }
                                 break;
                         case UNSPECIFIED:
                                 if(getCurrentParticipantsOthers() >= getMaxParticipantsOthers()){
-                                        return ApiResponse.fail(INCREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(INCREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsOthers(getCurrentParticipantsOthers() + 1);
                                 }
@@ -224,28 +225,28 @@ public class MatePost extends BaseEntity {
                 switch(position){
                         case CENTER:
                                 if(getCurrentParticipantsCenters() == 0){
-                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsCenters(getCurrentParticipantsCenters() - 1);
                                 }
                                 break;
                         case GUARD:
                                 if(getCurrentParticipantsGuards() == 0){
-                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsGuards(getCurrentParticipantsGuards() - 1);
                                 }
                                 break;
                         case FORWARD:
                                 if(getCurrentParticipantsForwards() == 0){
-                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsForwards(getCurrentParticipantsForwards() - 1);
                                 }
                                 break;
                         case UNSPECIFIED:
                                 if(getCurrentParticipantsOthers() == 0){
-                                        return ApiResponse.fail(DECREASE_POSITION_NOT_AVAILABLE);
+                                        throw new BaseException(DECREASE_POSITION_NOT_AVAILABLE);
                                 }else{
                                         updateCurrentParticipantsOthers(getCurrentParticipantsOthers() - 1);
                                 }

--- a/src/main/java/sync/slamtalk/mate/entity/Participant.java
+++ b/src/main/java/sync/slamtalk/mate/entity/Participant.java
@@ -95,7 +95,7 @@ public class Participant extends BaseEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Participant that = (Participant) o;
-        return participantId == that.participantId && Objects.equals(matePost, that.matePost);
+        return participantId == that.participantId && Objects.equals(participantTableId, that.participantTableId);
     }
 
     @Override

--- a/src/main/java/sync/slamtalk/mate/entity/PositionType.java
+++ b/src/main/java/sync/slamtalk/mate/entity/PositionType.java
@@ -6,5 +6,5 @@ package sync.slamtalk.mate.entity;
  * 추후 협의를 통해 하나의 ENUM으로 통합할 수 있음
  * */
 public enum PositionType {
-    FORWARD, GUARD, CENTER, ALL
+    FORWARD, GUARD, CENTER, UNSPECIFIED
 }

--- a/src/main/java/sync/slamtalk/mate/entity/RecruitedSkillLevelType.java
+++ b/src/main/java/sync/slamtalk/mate/entity/RecruitedSkillLevelType.java
@@ -1,0 +1,5 @@
+package sync.slamtalk.mate.entity;
+
+public enum RecruitedSkillLevelType {
+    BEGINNER, OVER_BEGINNER, UNDER_LOW, OVER_LOW, UNDER_MIDDLE, OVER_MIDDLE, UNDER_HIGH, HIGH
+}

--- a/src/main/java/sync/slamtalk/mate/entity/SkillLevelType.java
+++ b/src/main/java/sync/slamtalk/mate/entity/SkillLevelType.java
@@ -1,5 +1,12 @@
 package sync.slamtalk.mate.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum SkillLevelType {
-    BEGINNER, INTERMEDIATE, MASTER, IRRELAVANT
+    HIGH("고수"), MIDDLE("중수"), LOW("하수"), BEGINNER("입문");
+
+    private final String level;
 }

--- a/src/main/java/sync/slamtalk/mate/error/MateErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/mate/error/MateErrorResponseCode.java
@@ -5,7 +5,7 @@ import sync.slamtalk.common.ResponseCodeDetails;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
-public enum UserErrorResponseCode implements ResponseCodeDetails {
+public enum MateErrorResponseCode implements ResponseCodeDetails {
     MATE_POST_NOT_FOUND(SC_NOT_FOUND, 4041, "해당 모집 글을 찾을 수 없습니다."),
     PARTICIPANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 참여자를 찾을 수 없습니다."),
     PARTICIPANT_ALREADY_REJECTED(SC_BAD_REQUEST, 4001, "이미 거절된 참여자입니다."),
@@ -14,7 +14,7 @@ public enum UserErrorResponseCode implements ResponseCodeDetails {
 
     USER_NOT_AUTHORIZED(SC_BAD_REQUEST, 4002, "접근한 유저는 해당 권한이 없습니다.");
 
-    UserErrorResponseCode(int code, int status, String message) {
+    MateErrorResponseCode(int code, int status, String message) {
         this.code = code;
         this.status = status;
         this.message = message;

--- a/src/main/java/sync/slamtalk/mate/error/MateErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/mate/error/MateErrorResponseCode.java
@@ -6,13 +6,14 @@ import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 public enum MateErrorResponseCode implements ResponseCodeDetails {
-    MATE_POST_NOT_FOUND(SC_NOT_FOUND, 4041, "해당 모집 글을 찾을 수 없습니다."),
-    PARTICIPANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 참여자를 찾을 수 없습니다."),
+
     PARTICIPANT_ALREADY_REJECTED(SC_BAD_REQUEST, 4001, "이미 거절된 참여자입니다."),
-
+    USER_NOT_AUTHORIZED(SC_BAD_REQUEST, 4002, "접근한 유저는 해당 권한이 없습니다."),
     PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS(SC_BAD_REQUEST, 4003, "해당 참여자는 상태를 변경할 수 없습니다."),
-
-    USER_NOT_AUTHORIZED(SC_BAD_REQUEST, 4002, "접근한 유저는 해당 권한이 없습니다.");
+    DECREASE_POSITION_NOT_AVAILABLE(SC_BAD_REQUEST, 4004, "해당 포지션의 모집 인원을 감소시킬 수 없습니다."),
+    INCREASE_POSITION_NOT_AVAILABLE(SC_BAD_REQUEST, 4005, "해당 포지션의 모집 인원을 증가시킬 수 없습니다."),
+    MATE_POST_NOT_FOUND(SC_NOT_FOUND, 4041, "해당 모집 글을 찾을 수 없습니다."),
+    PARTICIPANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 참여자를 찾을 수 없습니다.");
 
     MateErrorResponseCode(int code, int status, String message) {
         this.code = code;

--- a/src/main/java/sync/slamtalk/mate/error/UserErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/mate/error/UserErrorResponseCode.java
@@ -10,11 +10,9 @@ public enum UserErrorResponseCode implements ResponseCodeDetails {
     PARTICIPANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 참여자를 찾을 수 없습니다."),
     PARTICIPANT_ALREADY_REJECTED(SC_BAD_REQUEST, 4001, "이미 거절된 참여자입니다."),
 
-    PARTICIPANT_ALREADY_ACCEPTED(SC_BAD_REQUEST, 4002, "이미 수락된 참여자입니다."),
     PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS(SC_BAD_REQUEST, 4003, "해당 참여자는 상태를 변경할 수 없습니다."),
 
-    USER_NOT_AUTHORIZED(SC_BAD_REQUEST, 4002, "접근한 유저는 해당 권한이 없습니다."),
-    APPLY_STATUS_NOT_FOUND(SC_NOT_FOUND, 4043, "해당 신청 상태를 찾을 수 없습니다.");
+    USER_NOT_AUTHORIZED(SC_BAD_REQUEST, 4002, "접근한 유저는 해당 권한이 없습니다.");
 
     UserErrorResponseCode(int code, int status, String message) {
         this.code = code;

--- a/src/main/java/sync/slamtalk/mate/error/UserErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/mate/error/UserErrorResponseCode.java
@@ -1,0 +1,47 @@
+package sync.slamtalk.mate.error;
+
+import sync.slamtalk.common.ResponseCodeDetails;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+public enum UserErrorResponseCode implements ResponseCodeDetails {
+    MATE_POST_NOT_FOUND(SC_NOT_FOUND, 4041, "해당 모집 글을 찾을 수 없습니다."),
+    PARTICIPANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 참여자를 찾을 수 없습니다."),
+    PARTICIPANT_ALREADY_REJECTED(SC_BAD_REQUEST, 4001, "이미 거절된 참여자입니다."),
+
+    PARTICIPANT_ALREADY_ACCEPTED(SC_BAD_REQUEST, 4002, "이미 수락된 참여자입니다."),
+    PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS(SC_BAD_REQUEST, 4003, "해당 참여자는 상태를 변경할 수 없습니다."),
+
+    USER_NOT_AUTHORIZED(SC_BAD_REQUEST, 4002, "접근한 유저는 해당 권한이 없습니다."),
+    APPLY_STATUS_NOT_FOUND(SC_NOT_FOUND, 4043, "해당 신청 상태를 찾을 수 없습니다.");
+
+    UserErrorResponseCode(int code, int status, String message) {
+        this.code = code;
+        this.status = status;
+        this.message = message;
+    }
+
+    private final int code;
+    private final int status;
+    private String message;
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/sync/slamtalk/mate/service/MatePostService.java
+++ b/src/main/java/sync/slamtalk/mate/service/MatePostService.java
@@ -1,6 +1,5 @@
 package sync.slamtalk.mate.service;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static sync.slamtalk.mate.error.UserErrorResponseCode.MATE_POST_NOT_FOUND;
+import static sync.slamtalk.mate.error.MateErrorResponseCode.MATE_POST_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/sync/slamtalk/mate/service/MatePostService.java
+++ b/src/main/java/sync/slamtalk/mate/service/MatePostService.java
@@ -43,6 +43,8 @@ public class MatePostService {
         MatePost post = optionalPost.get();
         List<MatePostApplicantDTO> participantsToArrayList = participantService.getParticipants(matePostId);
         MateFormDTO mateFormDTO = MateFormDTO.builder()
+                .matePostId(post.getMatePostId())
+                .writerId(post.getWriterId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .startScheduledTime(post.getStartScheduledTime())

--- a/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
+++ b/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
@@ -47,7 +47,7 @@ public class ParticipantService {
     public List<MatePostApplicantDTO> getParticipants(long matePostId){
         Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
         if(!optionalMatePost.isPresent()){
-            throw new BaseException(MateErrorResponseCode.MATE_POST_NOT_FOUND);
+            throw new BaseException(MATE_POST_NOT_FOUND);
         }
         MatePost post = optionalMatePost.get();
         List<Participant> participants = post.getParticipants();
@@ -78,7 +78,7 @@ public class ParticipantService {
         }
         MatePost matePost = OptionalMatePost.get();
         if(matePost.getWriterId() != hostId){ // 접근자가 게시글 작성자가 아닐 때
-            return ApiResponse.fail(USER_NOT_AUTHORIZED);
+            throw new BaseException(USER_NOT_AUTHORIZED);
         }else{
             Optional<Participant> optionalParticipant = participantRepository.findById(participantTableId);
             Participant participant;
@@ -92,7 +92,7 @@ public class ParticipantService {
                 participant.updateApplyStatus(ApplyStatusType.ACCEPTED);
                 matePost.increasePositionNumbers(participant.getPosition());
             }else{
-                return ApiResponse.fail(PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS); // 대기 중인(WAITING) 참여자가 아닐 때 상태를 변경할 수 없습니다.
+                throw new BaseException(PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS); // 대기 중인(WAITING) 참여자가 아닐 때 상태를 변경할 수 없습니다.
             }
         }
         return ApiResponse.ok();
@@ -125,7 +125,7 @@ public class ParticipantService {
         }
 
         if(!(participant.getParticipantId() == writerId)){
-            return ApiResponse.fail(USER_NOT_AUTHORIZED);
+            throw new BaseException(USER_NOT_AUTHORIZED);
         } else{
             if(participant.getApplyStatus().equals(ApplyStatusType.WAITING)){
                 participant.updateApplyStatus(ApplyStatusType.CANCEL);
@@ -133,7 +133,7 @@ public class ParticipantService {
                 participant.updateApplyStatus(ApplyStatusType.CANCEL);
                 matePost.reducePositionNumbers(participant.getPosition());
             }else{
-                return ApiResponse.fail(PARTICIPANT_ALREADY_REJECTED);
+                throw new BaseException(PARTICIPANT_ALREADY_REJECTED);
             }
             return ApiResponse.ok();
         }
@@ -158,12 +158,12 @@ public class ParticipantService {
             throw new BaseException(PARTICIPANT_NOT_FOUND);
         }
         if(!(matePost.getWriterId() == hostId)){
-            return ApiResponse.fail(USER_NOT_AUTHORIZED);
+            throw new BaseException(USER_NOT_AUTHORIZED);
         } else {
             if(participant.getApplyStatus().equals(ApplyStatusType.WAITING)) {  // 모집글 작성자는 대기 상태인 참여자만 거절할 수 있다.
                 participant.updateApplyStatus(ApplyStatusType.REJECTED);
             }else{
-                return ApiResponse.fail(PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS); // 해당 참여자는 상태를 변경할 수 없습니다.
+                throw new BaseException(PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS); // 해당 참여자는 상태를 변경할 수 없습니다.
             }
         }
         return ApiResponse.ok();

--- a/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
+++ b/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
@@ -7,7 +7,7 @@ import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.common.BaseException;
 import sync.slamtalk.mate.dto.MatePostApplicantDTO;
 import sync.slamtalk.mate.entity.*;
-import sync.slamtalk.mate.error.UserErrorResponseCode;
+import sync.slamtalk.mate.error.MateErrorResponseCode;
 import sync.slamtalk.mate.repository.MatePostRepository;
 import sync.slamtalk.mate.repository.ParticipantRepository;
 
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static sync.slamtalk.mate.error.UserErrorResponseCode.*;
+import static sync.slamtalk.mate.error.MateErrorResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +30,7 @@ public class ParticipantService {
     public MatePostApplicantDTO addParticipant(long matePostId, long participantId, String participantNIckname, MatePostApplicantDTO matePostApplicantDTO){
         Optional<MatePost> post = matePostRepository.findById(matePostId);
         if(!post.isPresent()){
-            throw new BaseException(UserErrorResponseCode.MATE_POST_NOT_FOUND);
+            throw new BaseException(MateErrorResponseCode.MATE_POST_NOT_FOUND);
         }
 
 
@@ -50,7 +50,7 @@ public class ParticipantService {
     public List<MatePostApplicantDTO> getParticipants(long matePostId){
         Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
         if(!optionalMatePost.isPresent()){
-            throw new BaseException(UserErrorResponseCode.MATE_POST_NOT_FOUND);
+            throw new BaseException(MateErrorResponseCode.MATE_POST_NOT_FOUND);
         }
         MatePost post = optionalMatePost.get();
         List<Participant> participants = post.getParticipants();
@@ -77,7 +77,7 @@ public class ParticipantService {
     public ApiResponse acceptParticipant(long matePostId, long participantTableId, long hostId){
         Optional<MatePost> OptionalMatePost = matePostRepository.findById(matePostId);
         if(!OptionalMatePost.isPresent()){
-            throw new BaseException(UserErrorResponseCode.MATE_POST_NOT_FOUND);
+            throw new BaseException(MateErrorResponseCode.MATE_POST_NOT_FOUND);
         }
         MatePost matePost = OptionalMatePost.get();
         if(matePost.getWriterId() != hostId){ // 접근자가 게시글 작성자가 아닐 때

--- a/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
+++ b/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
@@ -1,0 +1,175 @@
+package sync.slamtalk.mate.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.common.BaseException;
+import sync.slamtalk.mate.dto.MatePostApplicantDTO;
+import sync.slamtalk.mate.entity.*;
+import sync.slamtalk.mate.error.UserErrorResponseCode;
+import sync.slamtalk.mate.repository.MatePostRepository;
+import sync.slamtalk.mate.repository.ParticipantRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static sync.slamtalk.mate.error.UserErrorResponseCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParticipantService {
+
+    private final MatePostRepository matePostRepository;
+    private final ParticipantRepository participantRepository;
+
+    //
+    //todo : post가 null이면 어떤 값을 반환할 지 결정해야 한다.
+    //todo : applyStatus가 AWAITING이 아니면 어떤 값을 반환할 지 결정해야 한다.
+    public MatePostApplicantDTO addParticipant(long matePostId, long participantId, String participantNIckname, MatePostApplicantDTO matePostApplicantDTO){
+        Optional<MatePost> post = matePostRepository.findById(matePostId);
+        if(!post.isPresent()){
+            throw new BaseException(UserErrorResponseCode.MATE_POST_NOT_FOUND);
+        }
+
+
+        Participant participant = new Participant(participantId,
+                participantNIckname, matePostApplicantDTO.getPosition(),
+                matePostApplicantDTO.getSkillLevel());
+        participant.connectParent(post.get());
+        Participant resultParticipant = participantRepository.save(participant);
+
+        MatePostApplicantDTO resultParticipantDTO = new MatePostApplicantDTO(resultParticipant.getParticipantTableId(), resultParticipant.getApplyStatus());
+        return resultParticipantDTO;
+    }
+
+    // 해당 글의 참여자 목록을 불러온다.
+    // 참여자 목록은 참여자의 ID, 닉네임, 포지션, 실력, 신청 상태를 담고 있다.
+    // 취소하였거나 거절 당한 참여자는 제외한다.
+    public List<MatePostApplicantDTO> getParticipants(long matePostId){
+        Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
+        if(!optionalMatePost.isPresent()){
+            throw new BaseException(UserErrorResponseCode.MATE_POST_NOT_FOUND);
+        }
+        MatePost post = optionalMatePost.get();
+        List<Participant> participants = post.getParticipants();
+        ArrayList<MatePostApplicantDTO> matePostApplicantDTOs = new ArrayList<>();
+        for(Participant participant : participants){ // 참여자 목록에서 취소하였거나 거절 당한 참여자도 포함한다. * 수정 가능
+//            if(participant.getApplyStatus() == ApplyStatusType.REJECTED || participant.getApplyStatus() == ApplyStatusType.CANCEL){
+//                continue;
+//            }
+            MatePostApplicantDTO matePostApplicantDTO = new MatePostApplicantDTO(participant.getParticipantTableId(), participant.getParticipantNickname(), participant.getPosition(), participant.getSkillLevel(), participant.getApplyStatus());
+            matePostApplicantDTOs.add(matePostApplicantDTO);
+        }
+        return matePostApplicantDTOs;
+    }
+
+    /**
+     *참여자의 신청 상태를 변경한다.
+     *참여자의 신청 상태는 ACCEPTED, REJECTED, CANCEL이 있다.
+     *ACCEPTED : 모집 글 게시자가 참여자(AWAITING)를 수락했을 때
+     *REJECTED : 모집 글 게시자가 참여자(AWAITING)를 거절했을 때
+     *CANCEL : 참여자(AWAITING)가 취소를 선택했을 때
+     */
+
+    // 모집 글 게시자가 참여자를 수락했을 때
+    public ApiResponse acceptParticipant(long matePostId, long participantTableId, long hostId){
+        Optional<MatePost> OptionalMatePost = matePostRepository.findById(matePostId);
+        if(!OptionalMatePost.isPresent()){
+            throw new BaseException(UserErrorResponseCode.MATE_POST_NOT_FOUND);
+        }
+        MatePost matePost = OptionalMatePost.get();
+        if(matePost.getWriterId() != hostId){ // 접근자가 게시글 작성자가 아닐 때
+            return ApiResponse.fail(USER_NOT_AUTHORIZED);
+        }else{
+            Optional<Participant> optionalParticipant = participantRepository.findById(participantTableId);
+            Participant participant;
+            try{
+                participant = optionalParticipant.get();
+            }catch(Exception e){
+                throw new BaseException(PARTICIPANT_NOT_FOUND);
+            }
+
+            if(participant.getApplyStatus() == ApplyStatusType.WAITING){
+                participant.updateApplyStatus(ApplyStatusType.ACCEPTED);
+                matePost.increasePositionNumbers(participant.getPosition());
+            }else{
+                return ApiResponse.fail(PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS); // 대기 중인(WAITING) 참여자가 아닐 때 상태를 변경할 수 없습니다.
+            }
+        }
+        return ApiResponse.ok();
+    }
+
+
+
+
+    // 참여자가 취소를 선택했을 때
+    // 접속자와 ID와 참여자의 ID가 일치하는지 확인한다.
+    // 참여자 목록의 해당 정보를 CANCEL로 변경한다.(연관관계는 그대로, softDelete는 false)
+    // 참여자가 취소를 선택했을 때 참여자 목록에서 삭제하는 것이 아니라 취소 상태로 변경하는 이유는 완전히 삭제되지 않는다면 연결된 정보는 남겨놔야 할거 같아서
+    // 취소를 눌러도 포지션별 인원의 변동은 없다.
+    // todo : 취소 로직을 수행한 후 성공 또는 실패 시 어떤 값을 프론트엔드에게 전달할 지 결정해야 한다.
+    // todo : userId가 String으로 바뀐다면 == 이 아닌 equals()를 사용해야 한다.
+    public ApiResponse cancelParticipant(long matePostId, long participantTableId, long writerId){
+        Optional<Participant> OptionalParticipant = participantRepository.findById(participantTableId);
+        Participant participant;
+        try{
+            participant = OptionalParticipant.get();
+        }catch(Exception e){
+            throw new BaseException(PARTICIPANT_NOT_FOUND);
+        }
+        Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
+        MatePost matePost;
+        try{
+            matePost = optionalMatePost.get();
+        }catch(Exception e){
+            throw new BaseException(MATE_POST_NOT_FOUND);
+        }
+
+        if(!(participant.getParticipantId() == writerId)){
+            return ApiResponse.fail(USER_NOT_AUTHORIZED);
+        } else{
+            if(participant.getApplyStatus().equals(ApplyStatusType.WAITING)){
+                participant.updateApplyStatus(ApplyStatusType.CANCEL);
+            }else if(participant.getApplyStatus().equals(ApplyStatusType.ACCEPTED)){ // 이미 수락된 참여자가 취소할 경우 해당 포지션의 모집 인원 수를 감소 시킵니다.
+                participant.updateApplyStatus(ApplyStatusType.CANCEL);
+                matePost.reducePositionNumbers(participant.getPosition());
+            }else{
+                return ApiResponse.fail(PARTICIPANT_ALREADY_REJECTED);
+            }
+            return ApiResponse.ok();
+        }
+    }
+
+    // 모집 글 게시자가 참여자를 거절했을 때
+    // 접속자와 ID와 모집 글 작성자의 ID가 일치하는지 확인한다.
+    // 승낙 전 참여자를 거절하기 때문에 포지션별 인원의 변동은 없다.
+    // todo : 수락 전 대기 상태인 신청자를 모집 글의 포지션 별 현재 모집 인원 수에 반영해야 할지 논의해야 한다.
+    public ApiResponse rejectParticipant(long matePostId, long participantTableId, long hostId){
+        Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
+        if(!optionalMatePost.isPresent()){
+            throw new BaseException(MATE_POST_NOT_FOUND);
+        }
+        MatePost matePost = optionalMatePost.get();
+        Optional<Participant> optionalParticipant = participantRepository.findById(participantTableId);
+        Participant participant;
+        try{
+            participant = optionalParticipant.get();
+        }catch(Exception e){
+            throw new BaseException(PARTICIPANT_NOT_FOUND);
+        }
+        if(!(matePost.getWriterId() == hostId)){
+            return ApiResponse.fail(USER_NOT_AUTHORIZED);
+        } else {
+            if(participant.getApplyStatus().equals(ApplyStatusType.WAITING)) {  // 모집글 작성자는 대기 상태인 참여자만 거절할 수 있다.
+                participant.updateApplyStatus(ApplyStatusType.REJECTED);
+            }else{
+                return ApiResponse.fail(PARTICIPANT_NOT_ALLOWED_TO_CHANGE_STATUS); // 해당 참여자는 상태를 변경할 수 없습니다.
+            }
+        }
+        return ApiResponse.ok();
+
+    }
+}

--- a/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
+++ b/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
@@ -32,8 +32,6 @@ public class ParticipantService {
         if(!post.isPresent()){
             throw new BaseException(MateErrorResponseCode.MATE_POST_NOT_FOUND);
         }
-
-
         Participant participant = new Participant(participantId,
                 participantNIckname, matePostApplicantDTO.getPosition(),
                 matePostApplicantDTO.getSkillLevel());
@@ -46,7 +44,6 @@ public class ParticipantService {
 
     // 해당 글의 참여자 목록을 불러온다.
     // 참여자 목록은 참여자의 ID, 닉네임, 포지션, 실력, 신청 상태를 담고 있다.
-    // 취소하였거나 거절 당한 참여자는 제외한다.
     public List<MatePostApplicantDTO> getParticipants(long matePostId){
         Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
         if(!optionalMatePost.isPresent()){
@@ -67,7 +64,7 @@ public class ParticipantService {
 
     /**
      *참여자의 신청 상태를 변경한다.
-     *참여자의 신청 상태는 ACCEPTED, REJECTED, CANCEL이 있다.
+     *참여자의 신청 상태는 ACCEPTED, REJECTED, CANCEL, WAITING(신청 시 기본 상태)이 있다.
      *ACCEPTED : 모집 글 게시자가 참여자(AWAITING)를 수락했을 때
      *REJECTED : 모집 글 게시자가 참여자(AWAITING)를 거절했을 때
      *CANCEL : 참여자(AWAITING)가 취소를 선택했을 때
@@ -105,11 +102,12 @@ public class ParticipantService {
 
 
     // 참여자가 취소를 선택했을 때
-    // 접속자와 ID와 참여자의 ID가 일치하는지 확인한다.
+    // 접속자 ID와 해당 신청자 ID가 일치하는지 확인한다.
     // 참여자 목록의 해당 정보를 CANCEL로 변경한다.(연관관계는 그대로, softDelete는 false)
     // 참여자가 취소를 선택했을 때 참여자 목록에서 삭제하는 것이 아니라 취소 상태로 변경하는 이유는 완전히 삭제되지 않는다면 연결된 정보는 남겨놔야 할거 같아서
     // 취소를 눌러도 포지션별 인원의 변동은 없다.
     // todo : userId가 String으로 바뀐다면 == 이 아닌 equals()를 사용해야 한다.
+    // todo : 현재 참여자 목록에서 완전히 삭제 하지 않았지만 재신청이 가능하다면 참여자 목록에서 삭제(hard delete)하는 것이 맞다고 생각한다.
     public ApiResponse cancelParticipant(long matePostId, long participantTableId, long writerId){
         Optional<Participant> OptionalParticipant = participantRepository.findById(participantTableId);
         Participant participant;
@@ -145,6 +143,7 @@ public class ParticipantService {
     // 접속자와 ID와 모집 글 작성자의 ID가 일치하는지 확인한다.
     // 승낙 전 참여자를 거절하기 때문에 포지션별 인원의 변동은 없다.
     // todo : 수락 전 대기 상태인 신청자를 모집 글의 포지션 별 현재 모집 인원 수에 반영해야 할지 논의해야 한다.
+    // todo : 현재 참여자 목록에서 완전히 삭제 하지 않았지만 재신청이 가능하다면 참여자 목록에서 삭제(hard delete)하는 것이 맞다고 생각한다.
     public ApiResponse rejectParticipant(long matePostId, long participantTableId, long hostId){
         Optional<MatePost> optionalMatePost = matePostRepository.findById(matePostId);
         if(!optionalMatePost.isPresent()){

--- a/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
+++ b/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
@@ -27,7 +27,6 @@ public class ParticipantService {
 
     //
     //todo : post가 null이면 어떤 값을 반환할 지 결정해야 한다.
-    //todo : applyStatus가 AWAITING이 아니면 어떤 값을 반환할 지 결정해야 한다.
     public MatePostApplicantDTO addParticipant(long matePostId, long participantId, String participantNIckname, MatePostApplicantDTO matePostApplicantDTO){
         Optional<MatePost> post = matePostRepository.findById(matePostId);
         if(!post.isPresent()){
@@ -110,7 +109,6 @@ public class ParticipantService {
     // 참여자 목록의 해당 정보를 CANCEL로 변경한다.(연관관계는 그대로, softDelete는 false)
     // 참여자가 취소를 선택했을 때 참여자 목록에서 삭제하는 것이 아니라 취소 상태로 변경하는 이유는 완전히 삭제되지 않는다면 연결된 정보는 남겨놔야 할거 같아서
     // 취소를 눌러도 포지션별 인원의 변동은 없다.
-    // todo : 취소 로직을 수행한 후 성공 또는 실패 시 어떤 값을 프론트엔드에게 전달할 지 결정해야 한다.
     // todo : userId가 String으로 바뀐다면 == 이 아닌 equals()를 사용해야 한다.
     public ApiResponse cancelParticipant(long matePostId, long participantTableId, long writerId){
         Optional<Participant> OptionalParticipant = participantRepository.findById(participantTableId);


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
-  신청자 목록 관련 기능 개발 (#47 이슈 참조)
-  메이트 찾기 및 신청자 목록 컨트롤러와 서비스 파일 분리.
-  엔터티 별 hashCode()와 equals(), 순환참조를 고려한 toString() 메서드 오버라이딩 함.
-  연관관계 편의 메서드 도입
-  프론트엔드와 조율하여 기능 수정
-  현재로써 일어날 법한 기본적인 예외 처리
-  ENUM 타입 통일을 위한 수정 및 추가
-  service계층의 메서드 별 여러가지 케이스를 고려한 테스트 진행 -> 통과
-  (*이슈 해결) 회원가입 API 요청이 실패로 돌아오는 이슈 해결!
-  api 요청 테스트 시 발생 이슈 해결! (#59 이슈 참조)

> 앞으로 진행할 예정인 이슈
- 프론트엔드로 반환하기 위한 SkillTypeList로 변환 메서드 생성
- 프론트엔드와 추가 논의 후 수정 작업 예정
- 다음 개발 단계 진행(메이트 찾기 글 목록)

closed #47 
closed #59
