### PR TITLE
#6 #56 Feature 소셜 로그인 기능 추가 및 토큰 저장 방식 리팩터링

### DIFF
--- a/src/main/java/sync/slamtalk/SlamtalkApplication.java
+++ b/src/main/java/sync/slamtalk/SlamtalkApplication.java
@@ -2,20 +2,11 @@ package sync.slamtalk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-
-//@SpringBootApplication
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class SlamtalkApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(SlamtalkApplication.class, args);
 	}
 
 }
-
-
-/*
-	Spring Security 의존성을 추가했지만,
-	아직 인증단계를 개발하지 않은 경우 Application에서 exclude를 이용해 Security 기능을 꺼둘 수 있다.
-*/

--- a/src/main/java/sync/slamtalk/security/config/CorsConfig.java
+++ b/src/main/java/sync/slamtalk/security/config/CorsConfig.java
@@ -22,6 +22,8 @@ public class  CorsConfig {
       config.addAllowedOrigin("http://localhost:3001");
       config.addAllowedHeader("*");
       config.addAllowedMethod("*");
+      // 다른도메인에서 오는 인증정보 포함을 허용할 경우 true로 설정
+      config.setAllowCredentials(true);
 
       // 클라이언트 response header 허용
       config.setExposedHeaders(Arrays.asList(

--- a/src/main/java/sync/slamtalk/security/dto/JwtTokenDto.java
+++ b/src/main/java/sync/slamtalk/security/dto/JwtTokenDto.java
@@ -9,13 +9,8 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class JwtTokenResponseDto {
+public class JwtTokenDto {
     private String grantType;
     private String accessToken;
     private String refreshToken;
-
-    /* refreshToken 초기화 메서드*/
-    public void clearRefreshToken(){
-        this.refreshToken = "";
-    }
 }

--- a/src/main/java/sync/slamtalk/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/sync/slamtalk/security/jwt/JwtTokenProvider.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import sync.slamtalk.common.BaseException;
-import sync.slamtalk.security.dto.JwtTokenResponseDto;
+import sync.slamtalk.security.dto.JwtTokenDto;
 import sync.slamtalk.security.utils.CookieUtil;
 import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.entity.User;
@@ -51,8 +51,6 @@ public class JwtTokenProvider implements InitializingBean {
     public String accessAuthorizationHeader;
     @Value("${jwt.refresh.header}")
     public String refreshAuthorizationCookieName;
-    @Value("${jwt.domain}")
-    private String domain;
 
     public JwtTokenProvider(
             @Value("${jwt.secretKey}") String secretKey,
@@ -81,7 +79,7 @@ public class JwtTokenProvider implements InitializingBean {
      * @return String
      */
     @Transactional
-    public JwtTokenResponseDto createToken(User user) {
+    public JwtTokenDto createToken(User user) {
 
         // 권한 정보 가져오기
         String authorities = user.getAuthorities().stream()
@@ -93,10 +91,9 @@ public class JwtTokenProvider implements InitializingBean {
         String accessToken = createAccessToken(user, authorities);
         String refreshToken = createRefreshToken();
 
-
         user.updateRefreshToken(refreshToken);
 
-        return new JwtTokenResponseDto(GRANT_TYPE, accessToken, refreshToken);
+        return new JwtTokenDto(GRANT_TYPE, accessToken, refreshToken);
     }
 
     /**
@@ -225,9 +222,8 @@ public class JwtTokenProvider implements InitializingBean {
      * @return Optional<JwtTokenResponseDto>
      * */
     @Transactional
-    public Optional<JwtTokenResponseDto> generateNewAccessToken(String refreshToken){
+    public Optional<JwtTokenDto> generateNewAccessToken(String refreshToken){
         log.debug("엑세스 토큰 재발급");
-        //todo : db 조회하는거
         User user = userRepository.findByRefreshToken(refreshToken)
                 .orElse(null);
 

--- a/src/main/java/sync/slamtalk/security/logout/CustomLogoutHandler.java
+++ b/src/main/java/sync/slamtalk/security/logout/CustomLogoutHandler.java
@@ -1,0 +1,41 @@
+package sync.slamtalk.security.logout;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import sync.slamtalk.security.utils.CookieUtil;
+import sync.slamtalk.user.entity.User;
+
+@Slf4j
+@Component
+public class CustomLogoutHandler implements LogoutHandler {
+    @Value("${jwt.refresh.header}")
+    public String refreshAuthorizationCookieName;
+    @Value("${jwt.domain}")
+    private String domain;
+
+    @Override
+    @Transactional
+    public void logout(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) {
+        log.debug("CustomLogoutHandler 동작");
+
+        if (authentication != null && authentication.getPrincipal() != null) {
+            User user = (User) authentication.getPrincipal();
+            // 로그아웃 로직
+            user.updateRefreshToken(null);
+        }
+
+        CookieUtil.deleteCookie(request, response, refreshAuthorizationCookieName, domain);
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/CustomOAuth2User.java
@@ -1,0 +1,43 @@
+package sync.slamtalk.security.oauth2;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.UserRole;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * DefaultOAuth2User를 상속하고, email과 role 필드를 추가로 가진다.
+ */
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String email;
+    private UserRole userRole;
+    private SocialType socialType;
+
+    /**
+     * Constructs a {@code DefaultOAuth2User} using the provided parameters.
+     *
+     * @param authorities      the authorities granted to the user
+     * @param attributes       the attributes about the user
+     * @param nameAttributeKey the key used to access the user's &quot;name&quot; from
+     *                         {@link #getAttributes()}
+     */
+    public CustomOAuth2User(
+            Collection<? extends GrantedAuthority> authorities,
+            Map<String, Object> attributes,
+            String nameAttributeKey,
+            String email,
+            UserRole userRole,
+            SocialType socialType
+    ) {
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.userRole = userRole;
+        this.socialType = socialType;
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/OAuthAttributes.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/OAuthAttributes.java
@@ -1,0 +1,102 @@
+package sync.slamtalk.security.oauth2;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import sync.slamtalk.security.oauth2.userinfo.KakaoOAuth2UserInfo;
+import sync.slamtalk.security.oauth2.userinfo.OAuth2UserInfo;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.entity.UserRole;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 각 소셜에서 받아오는 데이터가 다르므로
+ * 소셜별로 데이터를 받는 데이터를 분기 처리하는 DTO 클래스
+ */
+@Getter
+public class OAuthAttributes {
+
+    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private OAuth2UserInfo oauth2UserInfo; // 소셜 타입별 로그인 유저 정보(닉네임, 이메일, 프로필 사진 등등)
+
+    @Builder
+    private OAuthAttributes(
+            String nameAttributeKey,
+            OAuth2UserInfo oauth2UserInfo
+    ) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oauth2UserInfo = oauth2UserInfo;
+    }
+
+    /**
+     * SocialType에 맞는 메소드 호출하여 OAuthAttributes 객체 반환
+     * 파라미터 : userNameAttributeName -> OAuth2 로그인 시 키(PK)가 되는 값 / attributes : OAuth 서비스의 유저 정보들
+     * 소셜별 of 메소드(ofGoogle, ofKaKao, ofNaver)들은 각각 소셜 로그인 API에서 제공하는
+     * 회원의 식별값(id), attributes, nameAttributeKey를 저장 후 build
+     */
+    public static OAuthAttributes of(
+            SocialType socialType,
+            String userNameAttributeName,
+            Map<String, Object> attributes
+    ) {
+
+/*        if (socialType == SocialType.NAVER) {
+            return ofNaver(userNameAttributeName, attributes);
+        }*/
+        if (socialType == SocialType.KAKAO) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+/*        if(socialType == SocialType.GOOGLE){
+            return ofGoogle(userNameAttributeName, attributes);
+        }*/
+
+        // 지원하지 않는 SocialType이 들어온 경우 예외를 발생시킵니다.
+        throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다: " + socialType);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+/*    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new NaverOAuth2UserInfo(attributes))
+                .build();
+    }*/
+
+    /**
+     * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+     * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+     * email에는 UUID로 중복 없는 랜덤 값 생성
+     * role은 GUEST로 설정
+     */
+    public User toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+
+        return User.builder()
+                .email(oauth2UserInfo.getEmail())
+                .password(UUID.randomUUID().toString())
+                .nickname(oauth2UserInfo.getNickname())
+                .role(UserRole.GEUST)
+                .levelScore(0L)
+                .socialType(socialType)
+                .socialId(oauth2UserInfo.getId())
+                .imageUrl(oauth2UserInfo.getImageUrl())
+                .firstLoginCheck(true)
+                .build();
+
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,26 @@
+package sync.slamtalk.security.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        log.debug("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,92 @@
+package sync.slamtalk.security.oauth2.handler;
+
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import sync.slamtalk.security.jwt.JwtTokenProvider;
+import sync.slamtalk.security.oauth2.CustomOAuth2User;
+import sync.slamtalk.security.utils.CookieUtil;
+import sync.slamtalk.user.UserRepository;
+import sync.slamtalk.user.entity.User;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    @Value("${jwt.access.header}")
+    public String accessAuthorizationHeader;
+    @Value("${jwt.refresh.header}")
+    public String refreshAuthorizationCookieName;
+    @Value("${jwt.refresh.expiration}")
+    private int refreshTokenExpirationPeriod;
+    @Value("${jwt.domain}")
+    private String domain;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+        DefaultRedirectStrategy defaultRedirectStrategy = new DefaultRedirectStrategy();
+        defaultRedirectStrategy.setStatusCode(HttpStatus.TEMPORARY_REDIRECT);
+
+        log.debug("OAuth2 Login 성공!");
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        // User의 Role이 GUEST일 경우 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
+        Optional<User> optionalUser = userRepository.findByEmailAndSocialType(oAuth2User.getEmail(), oAuth2User.getSocialType());
+        if (optionalUser.isEmpty()) {
+            throw new EntityNotFoundException("유저 정보가 없습니다.");
+        }
+
+        User user = optionalUser.get();
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+        user.updateRefreshToken(refreshToken);
+
+        // HTTP 상태 코드 설정 - 301 Redirect
+        response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+
+        setRefreshTokenCookie(response, refreshToken);
+
+        response.sendRedirect("http://localhost:3000/login-success");
+    }
+
+
+    /**
+     * 쿠키에 리프레쉬 토큰을 저장하는 메서드
+     *
+     * @param response
+     * @param refreshToken
+     */
+    private void setRefreshTokenCookie(
+            HttpServletResponse response,
+            String refreshToken
+    ) {
+        CookieUtil.addCookie(
+                response,
+                refreshAuthorizationCookieName,
+                refreshToken,
+                refreshTokenExpirationPeriod,
+                domain
+        );
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,107 @@
+package sync.slamtalk.security.oauth2.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sync.slamtalk.security.oauth2.CustomOAuth2User;
+import sync.slamtalk.security.oauth2.OAuthAttributes;
+import sync.slamtalk.user.UserRepository;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.User;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+//    private static final String NAVER = "naver";
+    private static final String KAKAO = "kakao";
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.debug("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        /**
+         * DefaultOAuth2UserService 객체를 생성하여, loadUser(userRequest)를 통해 DefaultOAuth2User 객체를 생성 후 반환
+         * DefaultOAuth2UserService의 loadUser()는 소셜 로그인 API의 사용자 정보 제공 URI로 요청을 보내서
+         * 사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환한다.
+         * 결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저
+         */
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        /**
+         * userRequest에서 registrationId 추출 후 registrationId으로 SocialType 저장
+         * http://localhost:8080/oauth2/authorization/kakao에서 kakao가 registrationId
+         * userNameAttributeName은 이후에 nameAttributeKey로 설정된다.
+         */
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialType socialType = getSocialType(registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName(); // OAuth2 로그인 시 키(PK)가 되는 값
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
+
+        // socialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
+        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+
+        User createdUser = getUser(extractAttributes, socialType); // getUser() 메소드로 User 객체 생성 후 반환
+
+        // DefaultOAuth2User를 구현한 CustomOAuth2User 객체를 생성해서 반환
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdUser.getRole().getKey())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdUser.getEmail(),
+                createdUser.getRole(),
+                createdUser.getSocialType()
+        );
+    }
+
+    private SocialType getSocialType(String registrationId) {
+/*        if(NAVER.equals(registrationId)) {
+            return SocialType.NAVER;
+        }*/
+//        if(KAKAO.equals(registrationId)) {
+            return SocialType.KAKAO;
+//        }
+/*        return SocialType.GOOGLE;*/
+    }
+
+    /**
+     * SocialType과 attributes에 들어있는 소셜 로그인의 식별값 id를 통해 회원을 찾아 반환하는 메소드
+     * 만약 찾은 회원이 있다면, 그대로 반환하고 없다면 saveUser()를 호출하여 회원을 저장한다.
+     */
+    private User getUser(OAuthAttributes attributes, SocialType socialType) {
+        User findUser = userRepository.findBySocialTypeAndSocialId(socialType,
+                attributes.getOauth2UserInfo().getId()).orElse(null);
+
+        if(findUser == null) {
+            return saveUser(attributes, socialType);
+        }
+        return findUser;
+    }
+
+    /**
+     * OAuthAttributes의 toEntity() 메소드를 통해 빌더로 User 객체 생성 후 반환
+     * 생성된 User 객체를 DB에 저장 : socialType, socialId, email, role 값만 있는 상태
+     */
+    @Transactional
+    private User saveUser(OAuthAttributes attributes, SocialType socialType) {
+        User createdUser = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+        return userRepository.save(createdUser);
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package sync.slamtalk.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+
+    @Override
+    public String getEmail() {
+        return null;
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,49 @@
+package sync.slamtalk.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (account == null || profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (account == null || profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("thumbnail_image_url");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (account == null) {
+            return null;
+        }
+        return (String) account.get("email");
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,47 @@
+package sync.slamtalk.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("profile_image");
+    }
+
+    @Override
+    public String getEmail() {
+        return null;
+    }
+}

--- a/src/main/java/sync/slamtalk/security/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package sync.slamtalk.security.oauth2.userinfo;
+
+import java.util.Map;
+
+/**
+ * 소셜 타입별 유저 정보를 가지는 Oauth2UserInfo 추상클래스
+ * */
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    protected OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId(); //소셜 식별 값 : 구글 - "sub", 카카오 - "id", 네이버 - "id"
+
+    public abstract String getNickname();
+
+    public abstract String getImageUrl();
+
+    public abstract String getEmail();
+}

--- a/src/main/java/sync/slamtalk/security/utils/CookieUtil.java
+++ b/src/main/java/sync/slamtalk/security/utils/CookieUtil.java
@@ -41,7 +41,13 @@ public class CookieUtil {
      * @param maxAge
      * @param domain
      * */
-    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge, String domain) {
+    public static void addCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            int maxAge,
+            String domain
+    ) {
         ResponseCookie cookie = ResponseCookie.from(name, value) // 쿠키 이름과 값 설정
                 .path("/") // 쿠키 전체 도메인으로 경로 설정
                 .sameSite("None") // 쿠키가 같은 사이트 요청뿐만 아니라 크로스-사이트 요청에서도 전송될 수 있음
@@ -52,6 +58,7 @@ public class CookieUtil {
                 .build();
 
         log.debug("cookie 값 설정 ={}", cookie.toString());
+
         response.addHeader("Set-Cookie", cookie.toString());
     }
 
@@ -62,7 +69,12 @@ public class CookieUtil {
      * @param name
      * @param domain
      * */
-    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name, String domain) {
+    public static void deleteCookie(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String name,
+            String domain
+    ) {
         Cookie[] cookies = request.getCookies();
 
         if (cookies != null) {

--- a/src/main/java/sync/slamtalk/swagger/test/Controller.java
+++ b/src/main/java/sync/slamtalk/swagger/test/Controller.java
@@ -24,7 +24,7 @@ public class Controller {
             tags = {"유저", "관리자"} // 유저인지 관리자기능인지 여부
     )
     // 주의 사항 ApiResponse Swagger 도 동일한 클래스가 존재하기 때문에 import 주의 해야합니다.
-    public ApiResponse hello(
+    public ApiResponse<String> hello(
             String param,
             @AuthenticationPrincipal User user
     ){

--- a/src/main/java/sync/slamtalk/user/UserController.java
+++ b/src/main/java/sync/slamtalk/user/UserController.java
@@ -9,8 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
-import sync.slamtalk.security.dto.JwtTokenResponseDto;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
+import sync.slamtalk.user.dto.UserLoginResponseDto;
 import sync.slamtalk.user.dto.UserSignUpRequestDto;
 
 @Slf4j
@@ -23,12 +23,6 @@ public class UserController {
     public String authorizationHeader;
     @Value("${jwt.refresh.header}")
     public String refreshAuthorizationHeader;
-    @Value("${jwt.access.expiration}")
-    private int accessTokenExpirationPeriod;
-    @Value("${jwt.refresh.expiration}")
-    private int refreshTokenExpirationPeriod;
-    @Value("${jwt.domain}")
-    private String domain;
     private final UserService userService;
 
     /**
@@ -44,15 +38,15 @@ public class UserController {
             description = "자체 로그인 기능입니다.",
             tags = {"로그인/회원가입"}
     )
-    public ApiResponse<JwtTokenResponseDto> authorize(
+    public ApiResponse<UserLoginResponseDto> authorize(
             @Valid @RequestBody UserLoginRequestDto userLoginDto,
             HttpServletResponse response
     ) {
         // 1. username + password 를 기반으로 Authentication 객체 생성
         // 이때 authentication 은 인증 여부를 확인하는 authenticated 값이 false
-        JwtTokenResponseDto jwtTokenResponseDto = userService.login(userLoginDto, response);
+        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginDto, response);
 
-        return ApiResponse.ok(jwtTokenResponseDto);
+        return ApiResponse.ok(userLoginResponseDto);
     }
 
     /**
@@ -67,9 +61,11 @@ public class UserController {
             description = "자체 회원가입 기능입니다.",
             tags = {"로그인/회원가입"}
     )
-    public ApiResponse<String> signUp(@Valid @RequestBody UserSignUpRequestDto userSignUpDto) {
-        userService.signUp(userSignUpDto);
-        return ApiResponse.ok("회원가입 성공");
+    public ApiResponse<UserLoginResponseDto> signUp(
+            @Valid @RequestBody UserSignUpRequestDto userSignUpDto,
+            HttpServletResponse response) {
+        UserLoginResponseDto userLoginResponseDto = userService.signUp(userSignUpDto, response);
+        return ApiResponse.ok(userLoginResponseDto);
     }
 
     /**
@@ -85,12 +81,11 @@ public class UserController {
             description = "리프레쉬 토큰은 httpOnly secure 쿠키로 보내주고 엑세스 토큰은 헤더와 파라미터에 넣어 보내줍니다.",
             tags = {"로그인/회원가입"}
     )
-    public ApiResponse<JwtTokenResponseDto> refreshToken(
+    public ApiResponse<UserLoginResponseDto> refreshToken(
             HttpServletRequest request,
             HttpServletResponse response
     ){
-        JwtTokenResponseDto jwtTokenResponseDto = userService.refreshToken(request, response);
-
-        return ApiResponse.ok(jwtTokenResponseDto);
+        UserLoginResponseDto userLoginResponseDto = userService.refreshToken(request, response);
+        return ApiResponse.ok(userLoginResponseDto);
     }
 }

--- a/src/main/java/sync/slamtalk/user/UserRepository.java
+++ b/src/main/java/sync/slamtalk/user/UserRepository.java
@@ -2,18 +2,23 @@ package sync.slamtalk.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    @Query("select u from User u where  u.email = :email and u.socialType = :socialType")
-    Optional<User> findByEmailAndSocialType(String email, SocialType socialType);
+    @Query("select u from User u where  u.email = :email and u.socialType = :social_type")
+    Optional<User> findByEmailAndSocialType(
+            @Param("email") String email,
+            @Param("social_type") SocialType socialType
+    );
 
     Optional<User> findByNickname(String nickname);
 
-    @Query("select u from User u where u.refreshToken = :refreshToken")
-    Optional<User> findByRefreshToken(String refreshToken);
+    @Query("select u from User u where u.refreshToken = :refresh_token")
+    Optional<User> findByRefreshToken(@Param("refresh_token") String refreshToken);
 
+    Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String id);
 }

--- a/src/main/java/sync/slamtalk/user/UserService.java
+++ b/src/main/java/sync/slamtalk/user/UserService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +16,7 @@ import sync.slamtalk.security.dto.JwtTokenResponseDto;
 import sync.slamtalk.security.jwt.JwtTokenProvider;
 import sync.slamtalk.security.utils.CookieUtil;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
+import sync.slamtalk.user.dto.UserLoginResponseDto;
 import sync.slamtalk.user.dto.UserSignUpRequestDto;
 import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
@@ -52,26 +52,28 @@ public class UserService {
      * @return JwtTokenDto
      */
     @Transactional
-    public JwtTokenResponseDto login(
+    public UserLoginResponseDto login(
             UserLoginRequestDto userLoginDto,
             HttpServletResponse response
     ) {
         try {
-            // 1. email + password 를 기반으로 Authentication 객체 생성
-            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userLoginDto.getEmail(), userLoginDto.getPassword());
+            Authentication authentication = getAuthentication(userLoginDto.getEmail(), userLoginDto.getPassword());
 
-            // 2. 실제 검증. authenticate() 메서드를 통해 요청된 Member 에 대한 검증 진행
-            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-            log.debug("authenticationToken ={}", authenticationToken);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            User user = (User) authentication.getPrincipal();
 
             // 3. 인증 정보를 기반으로 JWT 토큰 생성)
-            JwtTokenResponseDto jwtTokenResponseDto = tokenProvider.createToken((User) authentication.getPrincipal());
+            JwtTokenResponseDto jwtTokenResponseDto = tokenProvider.createToken(user);
 
             response.addHeader(accessAuthorizationHeader, jwtTokenResponseDto.getAccessToken());
             setRefreshTokenCookie(response, jwtTokenResponseDto);
 
-            return jwtTokenResponseDto;
+            UserLoginResponseDto userLoginResponseDto = new UserLoginResponseDto(user.getFirstLoginCheck());
+
+            // 최초 정보수집을 위해 jwtTokenResponseDto의 firstLoginCheck은 true 로 반환, 이후는 false 로 반환하기 위한 로직
+            if(Boolean.TRUE.equals(user.getFirstLoginCheck())) user.updateFirstLoginCheck();
+
+            return userLoginResponseDto;
+
         } catch (Exception e) {
             throw new BaseException(UserErrorResponseCode.BAD_CREDENTIALS);
         }
@@ -81,24 +83,25 @@ public class UserService {
      * 회원가입 검증 및 회원가입 로직
      *
      * @param userSignUpDto
+     * @param response
+     * @return JwtTokenResponseDto
      */
     @Transactional
-    public void signUp(UserSignUpRequestDto userSignUpDto) {
+    public UserLoginResponseDto signUp(
+            UserSignUpRequestDto userSignUpDto,
+            HttpServletResponse response
+    ) {
+        // 중복 이메일 검증
+        checkEmailExistence(userSignUpDto);
+        // 중복 닉네임 검증
+        checkNicknameExistence(userSignUpDto);
 
-        if (userRepository.findByEmailAndSocialType(userSignUpDto.getEmail(), SocialType.LOCAL).isPresent()) {
-            log.debug("이미 존재하는 유저 이메일입니다.");
-            throw new BaseException(UserErrorResponseCode.EMAIL_ALREADY_EXISTS);
-        }
-
-        if (userRepository.findByNickname(userSignUpDto.getNickname()).isPresent()) {
-            log.debug("이미 존재하는 닉네임입니다.");
-            throw new BaseException(UserErrorResponseCode.NICKNAME_ALREADY_EXISTS);
-        }
-
-        User user = User.from(userSignUpDto);
+        User user = userSignUpDto.toEntity();
         user.passwordEncode(passwordEncoder);
 
         userRepository.save(user);
+
+        return login(new UserLoginRequestDto(userSignUpDto.getEmail(), userSignUpDto.getPassword()), response);
     }
 
     /**
@@ -109,12 +112,17 @@ public class UserService {
      * @return JwtTokenResponseDto
      */
     @Transactional
-    public JwtTokenResponseDto refreshToken(
+    public UserLoginResponseDto refreshToken(
             HttpServletRequest request,
             HttpServletResponse response
     ) {
 
         String refreshToken = tokenProvider.getRefreshTokenFromCookie(request);
+
+        // 토큰 만료 검사
+        if(!tokenProvider.validateToken(refreshToken)){
+            throw new BaseException(UserErrorResponseCode.INVALID_TOKEN);
+        }
 
         Optional<JwtTokenResponseDto> optionalJwtTokenResponseDto = tokenProvider.generateNewAccessToken(refreshToken);
 
@@ -124,10 +132,60 @@ public class UserService {
 
         JwtTokenResponseDto jwtTokenResponseDto = optionalJwtTokenResponseDto.get();
 
-        /* 엑세스 토큰및 리프레쉬 토큰 저장하는 로직 */
+        /* 엑세스 토큰 헤더에 저장 및 리프레쉬 토큰 쿠키에 저장하는 로직 */
         response.addHeader(accessAuthorizationHeader, jwtTokenResponseDto.getAccessToken());
         setRefreshTokenCookie(response, jwtTokenResponseDto);
-        return jwtTokenResponseDto;
+
+
+        // UserLoginResponseDto 생성 로직.
+        User user = userRepository.findByRefreshToken(jwtTokenResponseDto.getRefreshToken())
+                .orElseThrow(() -> new BaseException(UserErrorResponseCode.INVALID_TOKEN));
+
+        UserLoginResponseDto userLoginResponseDto = new UserLoginResponseDto(user.getFirstLoginCheck());
+
+        // 최초 정보수집을 위해 jwtTokenResponseDto의 firstLoginCheck은 true 로 반환, 이후는 false 로 반환하기 위한 로직
+        if(Boolean.TRUE.equals(user.getFirstLoginCheck())) user.updateFirstLoginCheck();
+
+        return userLoginResponseDto;
+    }
+
+    /**
+     * UsernamePasswordAuthenticationToken를 이용해서 email과 password를 통해
+     * SecurityContextHolder에서 Authentication을 추출하는 메서드
+     *
+     * @param  email
+     * @param  password
+     * @return Authentication
+     * */
+    private Authentication getAuthentication(String email, String password) {
+        // 1. email + password 를 기반으로 Authentication 객체 생성
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+
+        // 2. 실제 검증. authenticate() 메서드를 통해 요청된 Member 에 대한 검증 진행
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        log.debug("authenticationToken ={}", authenticationToken);
+
+        return authentication;
+    }
+
+    /**
+     * 회원가입 시 중복 닉네임이 존재하는지 검사하는 메서드
+     * */
+    private void checkNicknameExistence(UserSignUpRequestDto userSignUpDto) {
+        if (userRepository.findByNickname(userSignUpDto.getNickname()).isPresent()) {
+            log.debug("이미 존재하는 닉네임입니다.");
+            throw new BaseException(UserErrorResponseCode.NICKNAME_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 회원가입 시 중복 이메일이 존재하는지 검사하는 메서드
+     * */
+    private void checkEmailExistence(UserSignUpRequestDto userSignUpDto) {
+        if (userRepository.findByEmailAndSocialType(userSignUpDto.getEmail(), SocialType.LOCAL).isPresent()) {
+            log.debug("이미 존재하는 유저 이메일입니다.");
+            throw new BaseException(UserErrorResponseCode.EMAIL_ALREADY_EXISTS);
+        }
     }
 
     /**
@@ -146,7 +204,5 @@ public class UserService {
                 refreshTokenExpirationPeriod,
                 domain
         );
-
-        jwtTokenResponseDto.clearRefreshToken();
     }
 }

--- a/src/main/java/sync/slamtalk/user/UserService.java
+++ b/src/main/java/sync/slamtalk/user/UserService.java
@@ -12,7 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sync.slamtalk.common.BaseException;
-import sync.slamtalk.security.dto.JwtTokenResponseDto;
+import sync.slamtalk.security.dto.JwtTokenDto;
 import sync.slamtalk.security.jwt.JwtTokenProvider;
 import sync.slamtalk.security.utils.CookieUtil;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
@@ -62,7 +62,7 @@ public class UserService {
             User user = (User) authentication.getPrincipal();
 
             // 3. 인증 정보를 기반으로 JWT 토큰 생성)
-            JwtTokenResponseDto jwtTokenResponseDto = tokenProvider.createToken(user);
+            JwtTokenDto jwtTokenResponseDto = tokenProvider.createToken(user);
 
             response.addHeader(accessAuthorizationHeader, jwtTokenResponseDto.getAccessToken());
             setRefreshTokenCookie(response, jwtTokenResponseDto);
@@ -124,13 +124,13 @@ public class UserService {
             throw new BaseException(UserErrorResponseCode.INVALID_TOKEN);
         }
 
-        Optional<JwtTokenResponseDto> optionalJwtTokenResponseDto = tokenProvider.generateNewAccessToken(refreshToken);
+        Optional<JwtTokenDto> optionalJwtTokenResponseDto = tokenProvider.generateNewAccessToken(refreshToken);
 
         if (optionalJwtTokenResponseDto.isEmpty()) {
             throw new BaseException(UserErrorResponseCode.INVALID_TOKEN);
         }
 
-        JwtTokenResponseDto jwtTokenResponseDto = optionalJwtTokenResponseDto.get();
+        JwtTokenDto jwtTokenResponseDto = optionalJwtTokenResponseDto.get();
 
         /* 엑세스 토큰 헤더에 저장 및 리프레쉬 토큰 쿠키에 저장하는 로직 */
         response.addHeader(accessAuthorizationHeader, jwtTokenResponseDto.getAccessToken());
@@ -195,7 +195,7 @@ public class UserService {
      * */
     private void setRefreshTokenCookie(
             HttpServletResponse response,
-            JwtTokenResponseDto jwtTokenResponseDto
+            JwtTokenDto jwtTokenResponseDto
     ) {
         CookieUtil.addCookie(
                 response,

--- a/src/main/java/sync/slamtalk/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserLoginRequestDto.java
@@ -4,12 +4,10 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@ToString
 public class UserLoginRequestDto {
 
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$",

--- a/src/main/java/sync/slamtalk/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserLoginResponseDto.java
@@ -1,0 +1,10 @@
+package sync.slamtalk.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserLoginResponseDto {
+    private Boolean firstLoginCheck;
+}

--- a/src/main/java/sync/slamtalk/user/dto/UserSignUpRequestDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserSignUpRequestDto.java
@@ -1,14 +1,19 @@
 package sync.slamtalk.user.dto;
 
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.entity.UserRole;
 
 /**
  * 회원가입 시 받을 dto
  * */
-@NoArgsConstructor
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserSignUpRequestDto {
 
     @Pattern(
@@ -26,4 +31,21 @@ public class UserSignUpRequestDto {
             message = "닉네임은 특수문자를 제외한 2~13자리여야 합니다."
     )
     private String nickname;
+
+    /**
+     * userSignUpDto 를 User로 변환
+     *
+     * @return user 유저 entity
+     * */
+     public User toEntity(){
+         return User.builder()
+                 .email(this.getEmail())
+                 .password(this.getPassword())
+                 .nickname(this.getNickname())
+                 .role(UserRole.USER)
+                 .levelScore(0L)
+                 .socialType(SocialType.LOCAL)
+                 .firstLoginCheck(true)
+                 .build();
+     }
 }

--- a/src/main/java/sync/slamtalk/user/entity/User.java
+++ b/src/main/java/sync/slamtalk/user/entity/User.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import sync.slamtalk.chat.entity.UserChatRoom;
 import sync.slamtalk.common.BaseEntity;
-import sync.slamtalk.user.dto.UserSignUpRequestDto;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,9 +17,10 @@ import java.util.List;
 @Entity
 @Table(name = "users") // User가 예약어라서 users로 테이블이름 명시
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Getter
+@Builder
 public class User extends BaseEntity implements UserDetails {
     @Id  @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false)
@@ -31,8 +31,8 @@ public class User extends BaseEntity implements UserDetails {
     private String nickname;
     @Column(nullable = false)
     private String email;
-    @Column(name = "image_uri")
-    private String imageUri;
+    @Column(name = "image_url")
+    private String imageUrl;
     @Column(name = "refresh_token")
     private String refreshToken;
 
@@ -51,6 +51,10 @@ public class User extends BaseEntity implements UserDetails {
     private String selfIntroduction;
     @Column(name = "region_name")
     private String regionName;
+
+    /* 정보 수집 부분 */
+    @Column(name = "first_login_check", nullable = false)
+    private Boolean firstLoginCheck;
     @Column(name = "basketball_skill_level")
     @Enumerated(EnumType.STRING)
     private UserBasketballSkillLevelType basketballSkillLevel;
@@ -67,8 +71,6 @@ public class User extends BaseEntity implements UserDetails {
     private Long levelScore = 0L;
 
     /* 연관 관계 매핑 */
-
-    // todo : 예지님 연관관계 매핑 부분
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserChatRoom> userChatRooms = new ArrayList<>();
 
@@ -88,26 +90,20 @@ public class User extends BaseEntity implements UserDetails {
     }
 
     /**
-     * userSignUpDto 를 User로 변환
-     * @param userSignUpDto 유저회원가입 dto
-     * @return user 유저 entity
+     * 리프레쉬 토큰 update하는 메서드
+     *
+     * @param refreshToken
      * */
-    public static User from(UserSignUpRequestDto userSignUpDto) {
-
-        User user = new User();
-        user.email = userSignUpDto.getEmail();
-        user.password = userSignUpDto.getPassword();
-        user.nickname = userSignUpDto.getNickname();
-        user.role = UserRole.USER;
-        user.levelScore = 0L;
-        user.socialType = SocialType.LOCAL;
-        return user;
-    }
-
     public void updateRefreshToken(String refreshToken){
         this.refreshToken = refreshToken;
     }
 
+    /**
+     * 최초 로그인 상태를 false로 설정하는 메서드
+     * */
+    public void updateFirstLoginCheck(){
+        this.firstLoginCheck = false;
+    }
 
     /* UserDetails 관련 메서드 */
     @Override

--- a/src/test/java/sync/slamtalk/user/UserServiceTest.java
+++ b/src/test/java/sync/slamtalk/user/UserServiceTest.java
@@ -4,21 +4,12 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.lang.annotation.Before;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import sync.slamtalk.security.dto.JwtTokenResponseDto;
 import sync.slamtalk.security.jwt.JwtTokenProvider;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
 import sync.slamtalk.user.dto.UserLoginResponseDto;
@@ -26,9 +17,8 @@ import sync.slamtalk.user.dto.UserSignUpRequestDto;
 import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @Slf4j

--- a/src/test/java/sync/slamtalk/user/UserServiceTest.java
+++ b/src/test/java/sync/slamtalk/user/UserServiceTest.java
@@ -1,0 +1,101 @@
+package sync.slamtalk.user;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import sync.slamtalk.security.dto.JwtTokenResponseDto;
+import sync.slamtalk.security.jwt.JwtTokenProvider;
+import sync.slamtalk.user.dto.UserLoginRequestDto;
+import sync.slamtalk.user.dto.UserLoginResponseDto;
+import sync.slamtalk.user.dto.UserSignUpRequestDto;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.User;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@Slf4j
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    public UserRepository userRepository;
+    @Autowired
+    public UserService userService;
+    @Autowired
+    public JwtTokenProvider jwtTokenProvider;
+
+    public String email = "test1@naver.com";
+    public String password = "123@password!";
+    public String nickname = "nickname";
+    public UserLoginRequestDto userLoginRequestDto = new UserLoginRequestDto(email, password);
+
+    @DisplayName("회원가입")
+    @Test
+    void signUp() {
+        //given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        UserSignUpRequestDto userSignUpRequestDto = new UserSignUpRequestDto(email, password, nickname);
+
+        // when
+        UserLoginResponseDto userLoginResponseDto = userService.signUp(userSignUpRequestDto, response);
+
+        // then
+        assertTrue(userLoginResponseDto.getFirstLoginCheck());
+    }
+
+    @DisplayName("로그인")
+    @Test
+    void login() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto, response);
+
+        // then
+        assertFalse(userLoginResponseDto.getFirstLoginCheck());
+    }
+
+
+    @DisplayName("토큰 재발급")
+    @Test
+    void refreshToken() {
+        // given
+        // 모의 객체 생성
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // 테스트에 사용할 쿠키 생성 및 설정
+        User user = userRepository.findByEmailAndSocialType(this.email, SocialType.LOCAL)
+                .orElseThrow(() -> new RuntimeException("유저를 찾지 못함"));
+
+        Cookie[] cookies = new Cookie[]{
+                new Cookie("Refresh_Authorization", user.getRefreshToken())
+        };
+        Mockito.when(request.getCookies()).thenReturn(cookies);
+
+        // when
+        UserLoginResponseDto userLoginResponseDto = userService.refreshToken(request, response);
+
+        // then
+        assertFalse(userLoginResponseDto.getFirstLoginCheck());
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 소셜 로그인 구현하기
- 로그인 시 헤더에 Authroization 토큰 반환 및, 바디에 정보수집여부 반환
- OAuth 2.0 로직 추가
- 시큐리티 logout api 설정 추가
- 회원가입 시 로그인 까지 해주는 로직 추가
- 토큰 재발급 시에 쿠키에 있는 refreshToken을 이용해서 만료검사 및 엑세스토큰 리프레시 토큰 재발급 로직 리팩터링


## 💬 리뷰 요구사항 
- 통합 테스트 를 위해 총미님께 다음 내용을 공유할 예정입니다.

resolved : #6 
resolved : #56 
