### PR TITLE
#92 refactor  카카오 로그인 성공시 응답 url 수정

### DIFF
--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -67,7 +67,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         setRefreshTokenCookie(response, refreshToken);
 
-        response.sendRedirect("http://localhost:3000/login-success");
+        response.sendRedirect("http://localhost:3000");
     }
 
 


### PR DESCRIPTION
## 📝 #92 카카오 성공 응답 url 수정
- 변경점 : http://localhost:3000 로 변경되었습니다
- 이유 : 테스트 환경이라 localhost로 해두고 배포환경에서는 front측의 url로 수정할 계획입니다.