### PR TITLE
#80 유저 마이페이지 기능 구현(미완성)

### DIFF
--- a/src/main/java/sync/slamtalk/user/controller/AuthController.java
+++ b/src/main/java/sync/slamtalk/user/controller/AuthController.java
@@ -1,4 +1,4 @@
-package sync.slamtalk.user;
+package sync.slamtalk.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,21 +9,25 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.user.service.AuthService;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
 import sync.slamtalk.user.dto.UserLoginResponseDto;
 import sync.slamtalk.user.dto.UserSignUpRequestDto;
 
+/**
+ * 이 컨트롤러는 인증과 관련된 기능을 다루는 클래스입니다.
+ */
 @Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class UserController {
+public class AuthController {
 
     @Value("${jwt.access.header}")
     public String authorizationHeader;
     @Value("${jwt.refresh.header}")
     public String refreshAuthorizationHeader;
-    private final UserService userService;
+    private final AuthService authService;
 
     /**
      * 로그인 api
@@ -44,7 +48,7 @@ public class UserController {
     ) {
         // 1. username + password 를 기반으로 Authentication 객체 생성
         // 이때 authentication 은 인증 여부를 확인하는 authenticated 값이 false
-        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginDto, response);
+        UserLoginResponseDto userLoginResponseDto = authService.login(userLoginDto, response);
 
         return ApiResponse.ok(userLoginResponseDto);
     }
@@ -64,7 +68,7 @@ public class UserController {
     public ApiResponse<UserLoginResponseDto> signUp(
             @Valid @RequestBody UserSignUpRequestDto userSignUpDto,
             HttpServletResponse response) {
-        UserLoginResponseDto userLoginResponseDto = userService.signUp(userSignUpDto, response);
+        UserLoginResponseDto userLoginResponseDto = authService.signUp(userSignUpDto, response);
         return ApiResponse.ok(userLoginResponseDto);
     }
 
@@ -85,7 +89,7 @@ public class UserController {
             HttpServletRequest request,
             HttpServletResponse response
     ){
-        UserLoginResponseDto userLoginResponseDto = userService.refreshToken(request, response);
+        UserLoginResponseDto userLoginResponseDto = authService.refreshToken(request, response);
         return ApiResponse.ok(userLoginResponseDto);
     }
 }

--- a/src/main/java/sync/slamtalk/user/controller/AuthController.java
+++ b/src/main/java/sync/slamtalk/user/controller/AuthController.java
@@ -9,10 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
-import sync.slamtalk.user.service.AuthService;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
 import sync.slamtalk.user.dto.UserLoginResponseDto;
 import sync.slamtalk.user.dto.UserSignUpRequestDto;
+import sync.slamtalk.user.service.AuthService;
 
 /**
  * 이 컨트롤러는 인증과 관련된 기능을 다루는 클래스입니다.

--- a/src/main/java/sync/slamtalk/user/controller/UserController.java
+++ b/src/main/java/sync/slamtalk/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
      * */
     @GetMapping("/user/{userId}/info")
     @Operation(
-            summary = "유저 상세 정보 조회 api",
+            summary = "(미완성) 유저 상세 정보 조회 api",
             description = "유저가 본인이 아닐경우 email을 제외하고 보내줍니다.",
             tags = {"유저 상세정보 조회"}
     )

--- a/src/main/java/sync/slamtalk/user/controller/UserController.java
+++ b/src/main/java/sync/slamtalk/user/controller/UserController.java
@@ -1,0 +1,46 @@
+package sync.slamtalk.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.user.dto.UserDetailsInfoResponseDto;
+import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.service.UserService;
+
+/**
+ * 이 컨트롤러는 유저의 crud 와 관련된 클래스입니다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    /**
+     * 유저의 상세 정보 조회하는 api
+     * @param userId Pathvariable로 유저 id 받아오기
+     * @param user 시큐리티를 통해 user 정보를 받아옴
+     * @return UserDetailsInfoResponseDto 객체가 반환(개인정보 있는 버전, 없는 버전)
+     * */
+    @GetMapping("/user/{userId}/info")
+    @Operation(
+            summary = "유저 상세 정보 조회 api",
+            description = "유저가 본인이 아닐경우 email을 제외하고 보내줍니다.",
+            tags = {"유저 상세정보 조회"}
+    )
+    public ApiResponse<UserDetailsInfoResponseDto> userDetailsInfo(
+            @PathVariable("userId") Long userId,
+            @AuthenticationPrincipal User user
+    ) {
+        UserDetailsInfoResponseDto userDetailsInfoResponseDto= userService.userDetailsInfo(userId, user);
+
+        return ApiResponse.ok(userDetailsInfoResponseDto);
+    }
+}

--- a/src/main/java/sync/slamtalk/user/dto/UserDetailsInfoResponseDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserDetailsInfoResponseDto.java
@@ -1,0 +1,72 @@
+package sync.slamtalk.user.dto;
+
+import lombok.*;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.entity.UserBasketballPositionType;
+import sync.slamtalk.user.entity.UserBasketballSkillLevelType;
+
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class UserDetailsInfoResponseDto {
+    /* 개인 정보 관련 */
+    private String email;
+    private SocialType socialType;
+    private String regionName;
+    private String isAlarmSet;
+
+    /* 공개되어도 상관없는 부분 */
+    private Long id;
+    private String nickname;
+    private String imageUrl;
+
+    /* 마이페이지 기능 */
+    private String selfIntroduction;
+
+    /* 정보 수집 부분 */
+    private UserBasketballSkillLevelType basketballSkillLevel;
+    private UserBasketballPositionType basketballPosition;
+    private Long levelScore = 0L;
+
+    /**
+     * 나의 프로필 조회 시 필요한 정보를 반환하는 생성자
+     * @param user db에서 조회한 user 객체
+     * @return UserDetailsInfoResponseDto 개인정보 포함된 정보
+     * */
+    public static UserDetailsInfoResponseDto generateMyProfile(User user){
+        return UserDetailsInfoResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .imageUrl(user.getImageUrl())
+                .selfIntroduction(user.getSelfIntroduction())
+                .basketballSkillLevel(user.getBasketballSkillLevel())
+                .basketballPosition(user.getBasketballPosition())
+                .levelScore(user.getLevelScore())
+                .email(user.getEmail())
+                .socialType(user.getSocialType())
+                .regionName(user.getRegionName())
+                .isAlarmSet(user.getIsAlarmSet())
+                .build();
+
+    }
+
+    /**
+     * 상대방 프로필 조회 시 필요한 정보를 반환하는 생성자
+     * @param user db에서 조회한 user 객체
+     * @return UserDetailsInfoResponseDto 개인정보 제외된 정보
+     * */
+    public static UserDetailsInfoResponseDto generateOtherUserProfile(User user){
+        return UserDetailsInfoResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .imageUrl(user.getImageUrl())
+                .selfIntroduction(user.getSelfIntroduction())
+                .basketballSkillLevel(user.getBasketballSkillLevel())
+                .basketballPosition(user.getBasketballPosition())
+                .levelScore(user.getLevelScore())
+                .build();
+
+    }
+}

--- a/src/main/java/sync/slamtalk/user/dto/UserDetailsInfoResponseDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserDetailsInfoResponseDto.java
@@ -14,8 +14,6 @@ public class UserDetailsInfoResponseDto {
     /* 개인 정보 관련 */
     private String email;
     private SocialType socialType;
-    private String regionName;
-    private String isAlarmSet;
 
     /* 공개되어도 상관없는 부분 */
     private Long id;
@@ -29,6 +27,8 @@ public class UserDetailsInfoResponseDto {
     private UserBasketballSkillLevelType basketballSkillLevel;
     private UserBasketballPositionType basketballPosition;
     private Long levelScore = 0L;
+    private Long mateCompleteParticipationCount = 0L;
+    private Long teamMatchingCompleteParticipationCount = 0L;
 
     /**
      * 나의 프로필 조회 시 필요한 정보를 반환하는 생성자
@@ -44,10 +44,10 @@ public class UserDetailsInfoResponseDto {
                 .basketballSkillLevel(user.getBasketballSkillLevel())
                 .basketballPosition(user.getBasketballPosition())
                 .levelScore(user.getLevelScore())
+                .mateCompleteParticipationCount(0L)
+                .teamMatchingCompleteParticipationCount(0L)
                 .email(user.getEmail())
                 .socialType(user.getSocialType())
-                .regionName(user.getRegionName())
-                .isAlarmSet(user.getIsAlarmSet())
                 .build();
 
     }
@@ -66,6 +66,8 @@ public class UserDetailsInfoResponseDto {
                 .basketballSkillLevel(user.getBasketballSkillLevel())
                 .basketballPosition(user.getBasketballPosition())
                 .levelScore(user.getLevelScore())
+                .mateCompleteParticipationCount(0L)
+                .teamMatchingCompleteParticipationCount(0L)
                 .build();
 
     }

--- a/src/main/java/sync/slamtalk/user/error/UserErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/user/error/UserErrorResponseCode.java
@@ -7,10 +7,11 @@ import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 public enum UserErrorResponseCode implements ResponseCodeDetails {
     INVALID_TOKEN(SC_BAD_REQUEST,4001,"Token Invalid"),
-    LOGIN_FAIL(SC_UNAUTHORIZED,4011,"Failed Login"),
-    EMAIL_ALREADY_EXISTS(SC_BAD_REQUEST, 4012, "이미 존재하는 유저 이메일입니다."),
-    NICKNAME_ALREADY_EXISTS(SC_BAD_REQUEST, 4013, "이미 존재하는 닉네임입니다."),
-    BAD_CREDENTIALS(SC_BAD_REQUEST, 4014, "아이디 또는 비밀번호를 다시 확인해주세요.")
+    LOGIN_FAIL(SC_UNAUTHORIZED,4002,"Failed Login"),
+    EMAIL_ALREADY_EXISTS(SC_BAD_REQUEST, 4003, "이미 존재하는 유저 이메일입니다."),
+    NICKNAME_ALREADY_EXISTS(SC_BAD_REQUEST, 4004, "이미 존재하는 닉네임입니다."),
+    BAD_CREDENTIALS(SC_BAD_REQUEST, 4005, "아이디 또는 비밀번호를 다시 확인해주세요."),
+    NOT_FOUND_USER(SC_BAD_REQUEST, 4006, "해당 유저가 존재하지 않습니다")
     ;
 
     UserErrorResponseCode(int code, int status, String message) {

--- a/src/main/java/sync/slamtalk/user/service/AuthService.java
+++ b/src/main/java/sync/slamtalk/user/service/AuthService.java
@@ -1,4 +1,4 @@
-package sync.slamtalk.user;
+package sync.slamtalk.user.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,6 +15,7 @@ import sync.slamtalk.common.BaseException;
 import sync.slamtalk.security.dto.JwtTokenDto;
 import sync.slamtalk.security.jwt.JwtTokenProvider;
 import sync.slamtalk.security.utils.CookieUtil;
+import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.dto.UserLoginRequestDto;
 import sync.slamtalk.user.dto.UserLoginResponseDto;
 import sync.slamtalk.user.dto.UserSignUpRequestDto;
@@ -24,11 +25,14 @@ import sync.slamtalk.user.error.UserErrorResponseCode;
 
 import java.util.Optional;
 
+/**
+ * 이 컨트롤러는 유저의 인증과 관련된 기능을 다루는 클래스입니다.
+ * */
 @Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class UserService {
+public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/sync/slamtalk/user/service/UserService.java
+++ b/src/main/java/sync/slamtalk/user/service/UserService.java
@@ -28,7 +28,7 @@ public class UserService {
 
 
         // 찾고자 하는 유저가 본인일 경우(상세한 개인정보 까지 공개)
-        if(user.getId().equals(userId)) return UserDetailsInfoResponseDto.generateMyProfile(user);
+        if(user.getId().equals(findUser.getId())) return UserDetailsInfoResponseDto.generateMyProfile(user);
         // 찾고자 하는 유저가 본인이 아닐경우(개인정보 제외하고 공개)
         else return UserDetailsInfoResponseDto.generateOtherUserProfile(user);
     }

--- a/src/main/java/sync/slamtalk/user/service/UserService.java
+++ b/src/main/java/sync/slamtalk/user/service/UserService.java
@@ -1,0 +1,35 @@
+package sync.slamtalk.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sync.slamtalk.common.BaseException;
+import sync.slamtalk.user.UserRepository;
+import sync.slamtalk.user.dto.UserDetailsInfoResponseDto;
+import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.error.UserErrorResponseCode;
+
+/**
+ * 이 서비스는 유저의 crud 와 관련된 클래스입니다.
+ * */
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+
+    /**
+     * 유저의 마이페이지 보기 조회시 사용되는 서비스
+     *
+     *
+     * */
+    public UserDetailsInfoResponseDto userDetailsInfo(Long userId, User user) {
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
+
+
+        // 찾고자 하는 유저가 본인일 경우(상세한 개인정보 까지 공개)
+        if(user.getId().equals(userId)) return UserDetailsInfoResponseDto.generateMyProfile(user);
+        // 찾고자 하는 유저가 본인이 아닐경우(개인정보 제외하고 공개)
+        else return UserDetailsInfoResponseDto.generateOtherUserProfile(user);
+    }
+}

--- a/src/test/java/sync/slamtalk/user/AuthServiceTest.java
+++ b/src/test/java/sync/slamtalk/user/AuthServiceTest.java
@@ -16,6 +16,7 @@ import sync.slamtalk.user.dto.UserLoginResponseDto;
 import sync.slamtalk.user.dto.UserSignUpRequestDto;
 import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.service.AuthService;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,12 +24,12 @@ import static org.mockito.Mockito.mock;
 
 @Slf4j
 @SpringBootTest
-class UserServiceTest {
+class AuthServiceTest {
 
     @Autowired
     public UserRepository userRepository;
     @Autowired
-    public UserService userService;
+    public AuthService authService;
     @Autowired
     public JwtTokenProvider jwtTokenProvider;
 
@@ -45,7 +46,7 @@ class UserServiceTest {
         UserSignUpRequestDto userSignUpRequestDto = new UserSignUpRequestDto(email, password, nickname);
 
         // when
-        UserLoginResponseDto userLoginResponseDto = userService.signUp(userSignUpRequestDto, response);
+        UserLoginResponseDto userLoginResponseDto = authService.signUp(userSignUpRequestDto, response);
 
         // then
         assertTrue(userLoginResponseDto.getFirstLoginCheck());
@@ -58,7 +59,7 @@ class UserServiceTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         // when
-        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto, response);
+        UserLoginResponseDto userLoginResponseDto = authService.login(userLoginRequestDto, response);
 
         // then
         assertFalse(userLoginResponseDto.getFirstLoginCheck());
@@ -83,7 +84,7 @@ class UserServiceTest {
         Mockito.when(request.getCookies()).thenReturn(cookies);
 
         // when
-        UserLoginResponseDto userLoginResponseDto = userService.refreshToken(request, response);
+        UserLoginResponseDto userLoginResponseDto = authService.refreshToken(request, response);
 
         // then
         assertFalse(userLoginResponseDto.getFirstLoginCheck());


### PR DESCRIPTION
## 📝 작업 내용

- 유저 마이페이지에 들어갈 api 개발을 하였습니다
- 기존 로그인/회원가입/리프레쉬 토큰을 담당하던 UserService -> AuthService, UserController -> AuthController로 이름 변경 했습니다
- 프로필에서 닉네임, 이메일, 한마디, 포지션, 농구 실력, 활동 내역(레벨)를 표시한다.
- 미완성 : 팀 매칭 횟수, 농구 메이트 참여 횟수
- 사유 : 팀 매칭 테이블 미완 및 농구 Repo 동수님이 개발중이신 부분이 있어서 그것 다음부터 개발할 예정입니다!
