### PR TITLE
#89 #100 시큐리티필터링에 게스트 해당 url 추가하는 설정 

### DIFF
--- a/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
+++ b/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
@@ -4,6 +4,7 @@ package sync.slamtalk.security.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -77,6 +78,10 @@ public class SecurityConfig {
                                     "/v3/api-docs/**",
                                     "/favicon.ico"
                             ).permitAll();
+
+                            // 게스트 권환 설정
+                            request.requestMatchers(HttpMethod.GET,
+                                    "/api/map/courts/**").permitAll();
                             request.requestMatchers("/api/admin").hasRole(UserRole.ADMIN.toString());
                             request.anyRequest().authenticated();
                         }


### PR DESCRIPTION
## 📝 작업 내용

- 앞선 성환님이 작성하신 "/api/map/courts/**" 로 설정해두어서 해당 /api/map/courts 를 포함한 아래의 모든 하위 경로의 GET 매서드로의 요청을 permitAll(전체허용)하는 설정을 추가하였습니다.

