### PR TITLE
#95 팀매칭 신청자 엔티티, 계층구조 생성 및 팀매칭 목록 구현

### DIFF
--- a/src/main/java/sync/slamtalk/common/BaseEntity.java
+++ b/src/main/java/sync/slamtalk/common/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PreRemove;
+import lombok.Getter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;

--- a/src/main/java/sync/slamtalk/common/BaseEntity.java
+++ b/src/main/java/sync/slamtalk/common/BaseEntity.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PreRemove;
-import lombok.Getter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;

--- a/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/ParticipantController.java
@@ -50,7 +50,7 @@ public class ParticipantController {
             return participantService.acceptParticipant(matePostId, participantTableId, id);
         }else if(applyStatus == ApplyStatusType.REJECTED){
             return participantService.rejectParticipant(matePostId, participantTableId, id);
-        }else if(applyStatus == ApplyStatusType.CANCEL){
+        }else if(applyStatus == ApplyStatusType.CANCELED){
             return participantService.cancelParticipant(matePostId, participantTableId, id);
         }else{
             return ApiResponse.fail("잘못된 요청입니다.");

--- a/src/main/java/sync/slamtalk/mate/entity/ApplyStatusType.java
+++ b/src/main/java/sync/slamtalk/mate/entity/ApplyStatusType.java
@@ -6,5 +6,5 @@ package sync.slamtalk.mate.entity;
  */
 
 public enum ApplyStatusType {
-    WAITING, ACCEPTED, REJECTED, CANCEL
+    WAITING, ACCEPTED, REJECTED, CANCELED
 }

--- a/src/main/java/sync/slamtalk/mate/entity/MatePost.java
+++ b/src/main/java/sync/slamtalk/mate/entity/MatePost.java
@@ -30,10 +30,10 @@ public class MatePost extends BaseEntity {
         @Column(name = "mate_post_id")
         private long matePostId;
 
-        //@ManyToOne(fetch = FetchType.LAZY)
-        //@JoinColumn(nullable = false, name="writer_id")
+//        @ManyToOne(fetch = FetchType.LAZY)
+//        @JoinColumn(nullable = false, name="writer_id")
         @Column(name="writer_id")
-        private long writerId; // 글 작성자 아이디 * User 테이블과 매핑 필요
+        private Long writerId; // 글 작성자 아이디 * User 테이블과 매핑 필요
 
         @Column(nullable = true, name="location_detail")
         private String locationDetail; // 상세 시합 장소
@@ -59,7 +59,7 @@ public class MatePost extends BaseEntity {
 
         @Column(nullable = false, name="recruitment_status_type")
         @Enumerated(EnumType.STRING)
-        private RecruitmentStatusType recruitmentStatus; // 모집 마감 여부 "RECRUITING", "COMPLETED", "CANCEL"
+        private RecruitmentStatusType recruitmentStatus; // 모집 마감 여부 "RECRUITING", "COMPLETED", "CANCELED"
 
         @Column(nullable = false, name="max_participants_forward")
         private int maxParticipantsForwards; // 포워드 최대 참여 인원

--- a/src/main/java/sync/slamtalk/mate/entity/RecruitmentStatusType.java
+++ b/src/main/java/sync/slamtalk/mate/entity/RecruitmentStatusType.java
@@ -1,5 +1,5 @@
 package sync.slamtalk.mate.entity;
 
 public enum RecruitmentStatusType {
-    RECRUITING, COMPLETED, CANCEL
+    RECRUITING, COMPLETED, CANCELED
 }

--- a/src/main/java/sync/slamtalk/mate/service/MatePostService.java
+++ b/src/main/java/sync/slamtalk/mate/service/MatePostService.java
@@ -166,7 +166,7 @@ public class MatePostService {
     public List<MatePostDTO> getMatePostsByCurser(String cursorStr, int limit) {
         LocalDateTime cursor = LocalDateTime.parse(cursorStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
         log.debug("cursor: {}", cursor);
-        Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(0, limit);
         List<MatePost> listedMatePosts = matePostRepository.findByCreatedAtLessThanAndIsDeletedNotOrderByCreatedAtDesc(cursor, true, pageable);
         log.debug("listedMatePosts: {}", listedMatePosts);
         List<MatePostDTO> response = listedMatePosts.stream().map(MatePostEntityToDtoMapper::toMatePostDto).collect(Collectors.toList());

--- a/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
+++ b/src/main/java/sync/slamtalk/mate/service/ParticipantService.java
@@ -134,9 +134,9 @@ public class ParticipantService {
             throw new BaseException(USER_NOT_AUTHORIZED);
         } else{
             if(participant.getApplyStatus().equals(ApplyStatusType.WAITING)){
-                participant.updateApplyStatus(ApplyStatusType.CANCEL);
+                participant.updateApplyStatus(ApplyStatusType.CANCELED);
             }else if(participant.getApplyStatus().equals(ApplyStatusType.ACCEPTED)){ // 이미 수락된 참여자가 취소할 경우 해당 포지션의 모집 인원 수를 감소 시킵니다.
-                participant.updateApplyStatus(ApplyStatusType.CANCEL);
+                participant.updateApplyStatus(ApplyStatusType.CANCELED);
                 matePost.reducePositionNumbers(participant.getPosition());
             }else{
                 throw new BaseException(PARTICIPANT_ALREADY_REJECTED);

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -101,6 +101,13 @@ public class TeamMatchingController {
         return ApiResponse.ok();
     }
 
+    @Operation(
+            summary = "팀 매칭 리스트 조회",
+            description = "커서 페이징 방식으로 팀 매칭 글 리스트를 조회하는 api 입니다. " +
+                    "다음 글 목록을 불러오려면 이전 요청 응답 모델에 넣었던 cursor값을 쿼리파라미터의 cursor에 적어주세요. (yyyy-MM-dd HH:mm:ss.SSS)"
+                    + "limit은 한번 조회할 때 가져올 수 있는 최대 글 개수이며, 기본값은 10개입니다.",
+            tags = {"팀 매칭"}
+    )
     @GetMapping
     public ApiResponse getTeamMatchingList(@RequestParam(name="cursor", required = false) Optional<String> cursor, @RequestParam(name="limit", required = false) Optional<Integer> limit){
         List<ToTeamFormDTO> dtoList;
@@ -122,6 +129,11 @@ public class TeamMatchingController {
         return ApiResponse.ok(resultDto);
     }
 
+    @Operation(
+            summary = "팀 매칭 신청",
+            description = "팀 매칭 글에 신청하는 api 입니다.",
+            tags = {"팀 매칭 / 신청자 목록",}
+    )
     @PostMapping("/{teamMatchingId}/apply")
     public ApiResponse applyTeamMatching(@PathVariable("teamMatchingId") long teamMatchingId){
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
-import sync.slamtalk.team.entity.TeamMatchings;
+import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
 import sync.slamtalk.team.service.TeamMatchingService;
 
@@ -81,7 +81,7 @@ public class TeamMatchingController {
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         int userId = 1;
 
-        TeamMatchings teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow();
+        TeamMatching teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow();
 
         ToTeamFormDTO dto;
         // * 해당 게시글 등록 폼에 입력된 작성자 ID와 접속자 ID가 일치하는지 확인한다.

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
+import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
 import sync.slamtalk.team.entity.TeamMatching;
@@ -16,6 +17,10 @@ import sync.slamtalk.team.repository.TeamMatchingRepository;
 import sync.slamtalk.team.service.TeamMatchingService;
 
 import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -92,5 +97,17 @@ public class TeamMatchingController {
         }
 
         return ApiResponse.ok();
+    }
+
+    @GetMapping
+    public ApiResponse getTeamMatchingList(@RequestParam(name="cursor", required = false) Optional<String> cursor, @RequestParam(name="limit", required = false) Optional<Integer> limit){
+        List<ToTeamFormDTO> dtoList;
+        String cursorTime = cursor.orElse(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")));
+        int limitNumber = 10;
+        if(limit.isPresent()){
+            limitNumber = limit.get();
+        }
+        dtoList = teamMatchingService.getTeamMatchingList(limitNumber, cursorTime);
+        return ApiResponse.ok(dtoList);
     }
 }

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -13,6 +13,7 @@ import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToApplicantDto;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
+import sync.slamtalk.team.dto.ToTeamMatchingListDto;
 import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
 import sync.slamtalk.team.service.TeamMatchingService;
@@ -109,7 +110,16 @@ public class TeamMatchingController {
             limitNumber = limit.get();
         }
         dtoList = teamMatchingService.getTeamMatchingList(limitNumber, cursorTime);
-        return ApiResponse.ok(dtoList);
+        ToTeamMatchingListDto resultDto = new ToTeamMatchingListDto();
+        if(dtoList.size() == 0){
+            return ApiResponse.ok(resultDto);
+        }else if(dtoList.size() < limitNumber) {
+            resultDto.setCursor(null);
+        }else{
+            resultDto.setCursor(dtoList.get(dtoList.size() - 1).getCreatedAt());
+        }
+        resultDto.setTeamMatchingList(dtoList);
+        return ApiResponse.ok(resultDto);
     }
 
     @PostMapping("/{teamMatchingId}/apply")
@@ -117,11 +127,7 @@ public class TeamMatchingController {
         // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
         int userId = 1;
 
-        long chatroomId = teamMatchingService.applyTeamMatching(teamMatchingId, userId);
-
-        ToApplicantDto dto = new ToApplicantDto();
-        dto.setTeamMatchingId(teamMatchingId);
-        dto.setChatroomId(chatroomId);
+        ToApplicantDto dto = teamMatchingService.applyTeamMatching(teamMatchingId, userId);
 
         return ApiResponse.ok(dto);
     }

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
+import sync.slamtalk.team.dto.ToApplicantDto;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
 import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
@@ -110,4 +111,20 @@ public class TeamMatchingController {
         dtoList = teamMatchingService.getTeamMatchingList(limitNumber, cursorTime);
         return ApiResponse.ok(dtoList);
     }
+
+    @PostMapping("/{teamMatchingId}/apply")
+    public ApiResponse applyTeamMatching(@PathVariable("teamMatchingId") long teamMatchingId){
+        // * 토큰을 이용하여 유저 아이디를 포함한 유저 정보를 가져온다.
+        int userId = 1;
+
+        long chatroomId = teamMatchingService.applyTeamMatching(teamMatchingId, userId);
+
+        ToApplicantDto dto = new ToApplicantDto();
+        dto.setTeamMatchingId(teamMatchingId);
+        dto.setChatroomId(chatroomId);
+
+        return ApiResponse.ok(dto);
+    }
+
+
 }

--- a/src/main/java/sync/slamtalk/team/dto/ToApplicantDto.java
+++ b/src/main/java/sync/slamtalk/team/dto/ToApplicantDto.java
@@ -1,0 +1,11 @@
+package sync.slamtalk.team.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ToApplicantDto {
+    long chatroomId;
+    long TeamMatchingId;
+}

--- a/src/main/java/sync/slamtalk/team/dto/ToApplicantDto.java
+++ b/src/main/java/sync/slamtalk/team/dto/ToApplicantDto.java
@@ -1,11 +1,19 @@
 package sync.slamtalk.team.dto;
 
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import sync.slamtalk.mate.entity.ApplyStatusType;
+import sync.slamtalk.team.entity.TeamMatching;
 
 @Getter
 @Setter
 public class ToApplicantDto {
+
+    long teamApplicantTableId;
+    long applicantId;
     long chatroomId;
     long TeamMatchingId;
+    ApplyStatusType applyStatusType;
+    String applicantNickname;
 }

--- a/src/main/java/sync/slamtalk/team/dto/ToTeamFormDTO.java
+++ b/src/main/java/sync/slamtalk/team/dto/ToTeamFormDTO.java
@@ -1,6 +1,7 @@
 package sync.slamtalk.team.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
@@ -16,7 +17,10 @@ import java.util.List;
 
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ToTeamFormDTO {
+
+    private long teamMatchingId;
 
     @NotBlank(message = "팀명을 입력해주세요.")
     private String teamName;
@@ -56,5 +60,5 @@ public class ToTeamFormDTO {
     private RecruitmentStatusType recruitmentStatusType;
 
     @NonNull
-    private List<TeamApplicant> teamApplicants;
+    private List<ToApplicantDto> teamApplicantsDto;
 }

--- a/src/main/java/sync/slamtalk/team/dto/ToTeamFormDTO.java
+++ b/src/main/java/sync/slamtalk/team/dto/ToTeamFormDTO.java
@@ -9,8 +9,10 @@ import lombok.NonNull;
 import lombok.Setter;
 import sync.slamtalk.mate.entity.RecruitedSkillLevelType;
 import sync.slamtalk.mate.entity.RecruitmentStatusType;
+import sync.slamtalk.team.entity.TeamApplicant;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -52,4 +54,7 @@ public class ToTeamFormDTO {
     @NonNull
     @Enumerated(EnumType.STRING)
     private RecruitmentStatusType recruitmentStatusType;
+
+    @NonNull
+    private List<TeamApplicant> teamApplicants;
 }

--- a/src/main/java/sync/slamtalk/team/dto/ToTeamMatchingListDto.java
+++ b/src/main/java/sync/slamtalk/team/dto/ToTeamMatchingListDto.java
@@ -1,0 +1,19 @@
+package sync.slamtalk.team.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class ToTeamMatchingListDto {
+
+    List<ToTeamFormDTO> teamMatchingList;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+    LocalDateTime cursor;
+}

--- a/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
@@ -3,9 +3,15 @@ package sync.slamtalk.team.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import sync.slamtalk.common.BaseEntity;
+import sync.slamtalk.common.BaseException;
 import sync.slamtalk.mate.entity.ApplyStatusType;
+import sync.slamtalk.team.dto.ToApplicantDto;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_NOT_FOUND;
 
 @Entity
 @Getter
@@ -25,12 +31,26 @@ public class TeamApplicant extends BaseEntity {
     @Column(nullable = false)
     private String applicantNickname;
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private ApplyStatusType applyStatus; // WAITING, ACCEPTED, REJECTED, CANCELED
     private long chatroomId;
 
     public void connectTeamMatching(TeamMatching teamMatching) {
         this.teamMatching = teamMatching;
         teamMatching.getTeamApplicants().add(this);
+    }
+
+
+
+    public ToApplicantDto makeDto(){
+        ToApplicantDto dto = new ToApplicantDto();
+        dto.setApplicantId(this.applicantId);
+        dto.setApplicantNickname(this.applicantNickname);
+        dto.setApplyStatusType(this.applyStatus);
+        dto.setChatroomId(this.chatroomId);
+        dto.setTeamApplicantTableId(this.teamApplicantTableId);
+        dto.setTeamMatchingId(this.teamMatching.getTeamMatchingId());
+        return dto;
     }
 
     @Override

--- a/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
@@ -1,0 +1,59 @@
+package sync.slamtalk.team.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import sync.slamtalk.common.BaseEntity;
+
+import java.util.Objects;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamApplicant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long teamApplicantTableId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_matching_id")
+    private TeamMatching teamMatchingId;
+    @Column(nullable = false)
+    private long applicantId;
+    @Column(nullable = false)
+    private String applicantNickname;
+    @Column(nullable = false)
+    private boolean isChatroomCreated;
+    private long chatroomId;
+
+    public void connectTeamMatching(TeamMatching teamMatching) {
+        this.teamMatchingId = teamMatching;
+        teamMatching.getTeamApplicants().add(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TeamApplicant that = (TeamApplicant) o;
+        return teamApplicantTableId == that.teamApplicantTableId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(teamApplicantTableId);
+    }
+
+    @Override
+    public String toString() {
+        return "TeamApplicant{" +
+                "teamApplicantTableId=" + teamApplicantTableId +
+                ", teamMatchingId=" + teamMatchingId +
+                ", applicantId=" + applicantId +
+                ", applicantNickname='" + applicantNickname + '\'' +
+                ", isChatroomCreated=" + isChatroomCreated +
+                ", chatroomId=" + chatroomId +
+                '}';
+    }
+
+}

--- a/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
@@ -3,6 +3,7 @@ package sync.slamtalk.team.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import sync.slamtalk.common.BaseEntity;
+import sync.slamtalk.mate.entity.ApplyStatusType;
 
 import java.util.Objects;
 
@@ -17,17 +18,17 @@ public class TeamApplicant extends BaseEntity {
     private long teamApplicantTableId;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_matching_id")
-    private TeamMatching teamMatchingId;
+    private TeamMatching teamMatching;
     @Column(nullable = false)
     private long applicantId;
     @Column(nullable = false)
     private String applicantNickname;
     @Column(nullable = false)
-    private boolean isChatroomCreated;
+    private ApplyStatusType applyStatus; // WAITING, ACCEPTED, REJECTED, CANCELED
     private long chatroomId;
 
     public void connectTeamMatching(TeamMatching teamMatching) {
-        this.teamMatchingId = teamMatching;
+        this.teamMatching = teamMatching;
         teamMatching.getTeamApplicants().add(this);
     }
 
@@ -48,10 +49,10 @@ public class TeamApplicant extends BaseEntity {
     public String toString() {
         return "TeamApplicant{" +
                 "teamApplicantTableId=" + teamApplicantTableId +
-                ", teamMatchingId=" + teamMatchingId +
+                ", teamMatchingId=" + teamMatching.getTeamMatchingId() +
                 ", applicantId=" + applicantId +
                 ", applicantNickname='" + applicantNickname + '\'' +
-                ", isChatroomCreated=" + isChatroomCreated +
+                ", isChatroomCreated=" + applyStatus +
                 ", chatroomId=" + chatroomId +
                 '}';
     }

--- a/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class TeamApplicant extends BaseEntity {
 
     @Id

--- a/src/main/java/sync/slamtalk/team/entity/TeamApplyStatusType.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamApplyStatusType.java
@@ -1,0 +1,5 @@
+package sync.slamtalk.team.entity;
+
+public enum TeamApplyStatusType {
+    WAITING, CONNECTED, ACCEPTED
+}

--- a/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
@@ -3,15 +3,20 @@ package sync.slamtalk.team.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import sync.slamtalk.common.BaseEntity;
+import sync.slamtalk.common.BaseException;
 import sync.slamtalk.mate.entity.RecruitedSkillLevelType;
 import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
+import sync.slamtalk.team.dto.ToApplicantDto;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_NOT_FOUND;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
@@ -127,6 +132,7 @@ public class TeamMatching extends BaseEntity {
     }
 
     public ToTeamFormDTO toTeamFormDto(ToTeamFormDTO dto){
+        dto.setTeamMatchingId(this.teamMatchingId);
         dto.setTitle(this.title);
         dto.setContent(this.content);
         dto.setWriterId(this.writerId); // * writerId를 User 객체로 대체할 것!
@@ -138,6 +144,7 @@ public class TeamMatching extends BaseEntity {
         dto.setNumberOfMembers(this.numberOfMembers);
         dto.setCreatedAt(this.getCreatedAt());
         dto.setRecruitmentStatusType(this.recruitmentStatus);
+        dto.setTeamApplicantsDto(this.makeApplicantDto());
         return dto;
     }
 
@@ -169,5 +176,11 @@ public class TeamMatching extends BaseEntity {
         this.writerId = writerId;
         // * 연관관계 편의 메서드
         // todo: User 객체에 있는 teamMatchingList에 현재 객체를 추가한다.
+    }
+
+    public List<ToApplicantDto> makeApplicantDto(){
+        List<TeamApplicant> teamApplicants = getTeamApplicants();
+        List<ToApplicantDto> dto = teamApplicants.stream().map(TeamApplicant::makeDto).collect(Collectors.toList());
+        return dto;
     }
 }

--- a/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
@@ -9,6 +9,8 @@ import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -16,7 +18,7 @@ import java.util.Objects;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "teammatchinglist")
 @Getter
-public class TeamMatchings extends BaseEntity {
+public class TeamMatching extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long teamMatchingId;
@@ -37,7 +39,6 @@ public class TeamMatchings extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
     private String locationDetail;
 
     @Column(nullable = false)
@@ -56,6 +57,9 @@ public class TeamMatchings extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RecruitmentStatusType recruitmentStatus;
 
+    @OneToMany(mappedBy = "teamMatching", cascade = CascadeType.ALL)
+    private List<TeamApplicant> teamApplicants = new ArrayList<>();
+
 //    public void connectUser(long writerId){ // * writerId를 User 객체로 대체할 것!
 //        this.writerId = writerId;
 //    }
@@ -68,7 +72,7 @@ public class TeamMatchings extends BaseEntity {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        TeamMatchings that = (TeamMatchings) o;
+        TeamMatching that = (TeamMatching) o;
         return teamMatchingId == that.teamMatchingId;
     }
 

--- a/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
@@ -131,6 +131,10 @@ public class TeamMatching extends BaseEntity {
         this.connectParentUser(writerId);
     }
 
+    /*
+    * TeamMatching 객체를 ToTeamFormDTO로 변환하여 반환하는 메소드 입니다.
+    * TeamMatching 객체의 teamApplicants 리스트를 ToApplicantDto로 변환하여 순환참조를 방지합니다.
+     */
     public ToTeamFormDTO toTeamFormDto(ToTeamFormDTO dto){
         dto.setTeamMatchingId(this.teamMatchingId);
         dto.setTitle(this.title);
@@ -178,6 +182,7 @@ public class TeamMatching extends BaseEntity {
         // todo: User 객체에 있는 teamMatchingList에 현재 객체를 추가한다.
     }
 
+    // * 리스트 컬렉션에 저장된 TeamApplicant 객체를 ToApplicantDto로 변환하여 리스트로 반환하는 기능을 수행합니다.
     public List<ToApplicantDto> makeApplicantDto(){
         List<TeamApplicant> teamApplicants = getTeamApplicants();
         List<ToApplicantDto> dto = teamApplicants.stream().map(TeamApplicant::makeDto).collect(Collectors.toList());

--- a/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
@@ -18,6 +18,11 @@ import java.util.Objects;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "teammatchinglist")
 @Getter
+@NamedEntityGraph(
+        name = "TeamMatching.forEagerApplicants",
+        attributeNodes = @NamedAttributeNode("teamApplicants")
+
+)
 public class TeamMatching extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -121,7 +126,7 @@ public class TeamMatching extends BaseEntity {
         this.connectParentUser(writerId);
     }
 
-    public void toTeamFormDto(ToTeamFormDTO dto){
+    public ToTeamFormDTO toTeamFormDto(ToTeamFormDTO dto){
         dto.setTitle(this.title);
         dto.setContent(this.content);
         dto.setWriterId(this.writerId); // * writerId를 User 객체로 대체할 것!
@@ -133,6 +138,7 @@ public class TeamMatching extends BaseEntity {
         dto.setNumberOfMembers(this.numberOfMembers);
         dto.setCreatedAt(this.getCreatedAt());
         dto.setRecruitmentStatusType(this.recruitmentStatus);
+        return dto;
     }
 
     @Override

--- a/src/main/java/sync/slamtalk/team/error/TeamErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/team/error/TeamErrorResponseCode.java
@@ -8,8 +8,10 @@ import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 public enum TeamErrorResponseCode implements ResponseCodeDetails {
 
     TEAM_POST_NOT_FOUND(SC_NOT_FOUND, 4041, "해당 모집 글을 찾을 수 없습니다."),
-    TEAM_POST_ALREADY_DELETED(SC_BAD_REQUEST, 4006, "이미 삭제된 모집 글입니다.");
-
+    TEAM_POST_ALREADY_DELETED(SC_BAD_REQUEST, 4006, "이미 삭제된 모집 글입니다."),
+    PROHIBITED_TO_APPLY_TO_YOUR_POST(SC_BAD_REQUEST, 4007, "자신이 작성한 글에는 지원할 수 없습니다."),
+    TEAM_POST_IS_NOT_RECRUITING(SC_BAD_REQUEST, 4008, "모집이 마감된 글입니다."),
+    ALREADY_APPLIED_TO_THIS_POST(SC_BAD_REQUEST, 4009, "이미 지원한 글입니다.");
     TeamErrorResponseCode(int code, int status, String message) {
         this.code = code;
         this.status = status;

--- a/src/main/java/sync/slamtalk/team/repository/TeamApplicantRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamApplicantRepository.java
@@ -1,0 +1,8 @@
+package sync.slamtalk.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sync.slamtalk.team.entity.TeamApplicant;
+
+public interface TeamApplicantRepository extends JpaRepository<TeamApplicant, Long> {
+
+}

--- a/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
@@ -17,14 +17,6 @@ import java.util.List;
 @Repository
 public interface TeamMatchingRepository extends JpaRepository<TeamMatching, Long> {
 
-    //    @Query("select t from TeamMatching t left join fetch t.teamApplicants where t.recruitmentStatus != :recruitmentStatus and t.createdAt < :cursor order by t.createdAt desc")
-//    List<TeamMatching> findAllOrderByCreatedAtDesc(@Param("recruitmentStatus") RecruitmentStatusType recruitmentStatus, @Param("cursor")LocalDateTime cursor, @Param("request")PageRequest request);
-    @Query("SELECT tm.teamMatchingId FROM TeamMatching tm WHERE tm.recruitmentStatus != :recruitmentStatus AND tm.createdAt < :cursor ORDER BY tm.createdAt DESC")
-    Page<Long> findTeamMatchingIds(@Param("recruitmentStatus") RecruitmentStatusType recruitmentStatus, @Param("cursor") LocalDateTime cursor, PageRequest request);
-
-    @Query("SELECT tm FROM TeamMatching tm LEFT JOIN FETCH tm.teamApplicants WHERE tm.teamMatchingId IN :ids")
-    List<TeamMatching> findTeamMatchingsWithApplicants(@Param("ids") List<Long> ids);
-
     @EntityGraph(value = "TeamMatching.forEagerApplicants", type= EntityGraph.EntityGraphType.LOAD)
     @Query("select t from TeamMatching t where t.createdAt < :cursor order by t.createdAt desc")
     List<TeamMatching> findAllByCreatedAtBefore(@Param("cursor")LocalDateTime cursor, PageRequest request);

--- a/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
@@ -2,8 +2,8 @@ package sync.slamtalk.team.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import sync.slamtalk.team.entity.TeamMatchings;
+import sync.slamtalk.team.entity.TeamMatching;
 
 @Repository
-public interface TeamMatchingRepository extends JpaRepository<TeamMatchings, Long> {
+public interface TeamMatchingRepository extends JpaRepository<TeamMatching, Long> {
 }

--- a/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
@@ -17,6 +17,7 @@ import java.util.List;
 @Repository
 public interface TeamMatchingRepository extends JpaRepository<TeamMatching, Long> {
 
+    // 팀 매칭 목록 조회를 위한 메소드 입니다. EntityGraph를 이용하여 즉시로딩으로 신청자 목록을 가져옵니다.(N + 1 문제 해결)
     @EntityGraph(value = "TeamMatching.forEagerApplicants", type= EntityGraph.EntityGraphType.LOAD)
     @Query("select t from TeamMatching t where t.createdAt < :cursor order by t.createdAt desc")
     List<TeamMatching> findAllByCreatedAtBefore(@Param("cursor")LocalDateTime cursor, PageRequest request);

--- a/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
@@ -1,9 +1,31 @@
 package sync.slamtalk.team.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.entity.TeamMatching;
+
+import java.awt.print.Pageable;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface TeamMatchingRepository extends JpaRepository<TeamMatching, Long> {
+
+    //    @Query("select t from TeamMatching t left join fetch t.teamApplicants where t.recruitmentStatus != :recruitmentStatus and t.createdAt < :cursor order by t.createdAt desc")
+//    List<TeamMatching> findAllOrderByCreatedAtDesc(@Param("recruitmentStatus") RecruitmentStatusType recruitmentStatus, @Param("cursor")LocalDateTime cursor, @Param("request")PageRequest request);
+    @Query("SELECT tm.teamMatchingId FROM TeamMatching tm WHERE tm.recruitmentStatus != :recruitmentStatus AND tm.createdAt < :cursor ORDER BY tm.createdAt DESC")
+    Page<Long> findTeamMatchingIds(@Param("recruitmentStatus") RecruitmentStatusType recruitmentStatus, @Param("cursor") LocalDateTime cursor, PageRequest request);
+
+    @Query("SELECT tm FROM TeamMatching tm LEFT JOIN FETCH tm.teamApplicants WHERE tm.teamMatchingId IN :ids")
+    List<TeamMatching> findTeamMatchingsWithApplicants(@Param("ids") List<Long> ids);
+
+    @EntityGraph(value = "TeamMatching.forEagerApplicants", type= EntityGraph.EntityGraphType.LOAD)
+    @Query("select t from TeamMatching t where t.createdAt < :cursor order by t.createdAt desc")
+    List<TeamMatching> findAllByCreatedAtBefore(@Param("cursor")LocalDateTime cursor, PageRequest request);
 }

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -2,14 +2,23 @@ package sync.slamtalk.team.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.common.BaseException;
+import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
 import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
+
+import java.awt.print.Pageable;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_ALREADY_DELETED;
 import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_NOT_FOUND;
@@ -47,5 +56,20 @@ public class TeamMatchingService {
     public ApiResponse deleteTeamMatching(long teamMatchingId, TeamMatching teamMatchingEntity){
         teamMatchingEntity.delete();
         return ApiResponse.ok();
+    }
+
+    public List<ToTeamFormDTO> getTeamMatchingList(int limit, String stringCursor){
+        PageRequest request = PageRequest.of(0, limit);
+        LocalDateTime cursor = LocalDateTime.parse(stringCursor, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+        log.debug("[TeamMatchingService] cursor : {}, request : {}",cursor, request);
+        long startTime = System.currentTimeMillis();
+//        Page<Long> pages = teamMatchingRepository.findTeamMatchingIds(recruitStatus, cursorDateTime, request);
+//        List<TeamMatching> result = teamMatchingRepository.findTeamMatchingsWithApplicants(pages.getContent());
+        List<TeamMatching> result = teamMatchingRepository.findAllByCreatedAtBefore(cursor, request);
+        log.debug("[TeamMatchingService] result : {}", result);
+        long endTime = System.currentTimeMillis();
+        log.debug("[TeamMatchingService] executed query time : {}", endTime - startTime);
+        List<ToTeamFormDTO> dtoList = result.stream().map(teamMatchingEntity -> teamMatchingEntity.toTeamFormDto(new ToTeamFormDTO())).toList();
+        return dtoList;
     }
 }

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -31,6 +31,9 @@ public class TeamMatchingService {
     private final TeamMatchingRepository teamMatchingRepository;
     private final TeamApplicantRepository teamApplicantRepository;
 
+    /*
+    * 팀 매칭 글을 등록하는 메소드 입니다.
+     */
     public long registerTeamMatching(FromTeamFormDTO dto, long userId){
         TeamMatching teamMatchingEntity = new TeamMatching();
         teamMatchingEntity.createTeamMatching(dto, userId);
@@ -38,6 +41,11 @@ public class TeamMatchingService {
         return resultTeamMatchingEntity.getTeamMatchingId();
     }
 
+    /*
+    * 팀 매칭 글을 조회하는 메소드 입니다.
+    * 인자로 받은 id를 가진 팀 매칭 글이 없을 경우 BaseException을 발생시킵니다.
+    * 팀 매칭 글이 삭제되었을 경우 BaseException을 발생시킵니다.
+     */
     public ToTeamFormDTO getTeamMatching(long teamMatchingId){
         TeamMatching teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow(() -> new BaseException(TEAM_POST_NOT_FOUND));
         if(teamMatchingEntity.getIsDeleted()){
@@ -48,17 +56,31 @@ public class TeamMatchingService {
         return dto;
     }
 
+    /*
+    * 팀 매칭 글을 수정하는 메소드 입니다.
+     */
     public ApiResponse updateTeamMatching(long teamMatchingId, FromTeamFormDTO fromTeamFormDTO){
         TeamMatching teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow();
         teamMatchingEntity.updateTeamMatching(fromTeamFormDTO);
         return ApiResponse.ok();
     }
 
+    /*
+    * 팀 매칭 글을 삭제하는 메소드 입니다.
+     */
     public ApiResponse deleteTeamMatching(long teamMatchingId, TeamMatching teamMatchingEntity){
         teamMatchingEntity.delete();
         return ApiResponse.ok();
     }
 
+    /*
+    * 팀 매칭 목록 조회를 위한 메소드 입니다. 최신 등록일자 순으로 조회합니다.
+    * 커서 페이징 방식으로 구현 하였고 다음의 인자를 받습니다.
+    * limit : 한번에 가져올 목록의 개수
+    * stringCursor : 커서로 사용할 날짜시간 문자열 입니다. 이 값은 LocalDateTime.parse를 통해 LocalDateTime으로 변환됩니다.
+    * log.debug를 통해 쿼리가 실행된 시간을 확인할 수 있습니다.
+    * ToTeamFormDTO 타입의 리스트를 반환합니다.
+     */
     public List<ToTeamFormDTO> getTeamMatchingList(int limit, String stringCursor){
         PageRequest request = PageRequest.of(0, limit);
         LocalDateTime cursor = LocalDateTime.parse(stringCursor, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -1,5 +1,6 @@
 package sync.slamtalk.team.service;
 
+import jakarta.persistence.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -8,20 +9,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.common.BaseException;
+import sync.slamtalk.mate.entity.ApplyStatusType;
 import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
+import sync.slamtalk.team.entity.TeamApplicant;
 import sync.slamtalk.team.entity.TeamMatching;
+import sync.slamtalk.team.repository.TeamApplicantRepository;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
 
 import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_ALREADY_DELETED;
-import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_NOT_FOUND;
+import static sync.slamtalk.team.error.TeamErrorResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +33,7 @@ import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_NOT_FOUND
 @Slf4j
 public class TeamMatchingService {
     private final TeamMatchingRepository teamMatchingRepository;
+    private final TeamApplicantRepository teamApplicantRepository;
 
     public long registerTeamMatching(FromTeamFormDTO dto, long userId){
         TeamMatching teamMatchingEntity = new TeamMatching();
@@ -71,5 +76,39 @@ public class TeamMatchingService {
         log.debug("[TeamMatchingService] executed query time : {}", endTime - startTime);
         List<ToTeamFormDTO> dtoList = result.stream().map(teamMatchingEntity -> teamMatchingEntity.toTeamFormDto(new ToTeamFormDTO())).toList();
         return dtoList;
+    }
+
+    public long applyTeamMatching(long teamMatchingId, long userId){
+        TeamMatching entity = teamMatchingRepository.findById(teamMatchingId).orElseThrow(()-> new BaseException(TEAM_POST_NOT_FOUND));
+        // * 글 작성자의 닉네임을 가져온다.
+        String writerNickname = "test";
+
+        // * 채팅방을 생성해서 채팅방 id를 가져온다.
+        long createdChatroomId = 1; // todo : 채팅방 생성 로직 완료시 해당 메서드를 통한 채팅방 id 가져오기
+
+        // * 글 작성자와 접속자가 같은지 확인한다.
+        if(entity.getWriterId() == userId){
+            throw new BaseException(PROHIBITED_TO_APPLY_TO_YOUR_POST);
+        }
+        // * 모집 상태가 모집 중인지 확인한다.
+        if(entity.getRecruitmentStatus() != RecruitmentStatusType.RECRUITING){
+            throw new BaseException(TEAM_POST_IS_NOT_RECRUITING);
+        }
+        // * 이미 지원한 작성자인지 확인한다.
+        entity.getTeamApplicants().forEach(applicant -> {
+            if(applicant.getApplicantId() == userId){
+                throw new BaseException(ALREADY_APPLIED_TO_THIS_POST);
+            }
+        });
+
+        TeamApplicant applicant = TeamApplicant.builder()
+                .applicantId(userId)
+                .applicantNickname(writerNickname)
+                .applyStatus(ApplyStatusType.WAITING)
+                .chatroomId(createdChatroomId)
+                .build();
+        applicant.connectTeamMatching(entity);
+        TeamApplicant result = teamApplicantRepository.save(applicant);
+        return result.getChatroomId();
     }
 }

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -8,7 +8,7 @@ import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.common.BaseException;
 import sync.slamtalk.team.dto.FromTeamFormDTO;
 import sync.slamtalk.team.dto.ToTeamFormDTO;
-import sync.slamtalk.team.entity.TeamMatchings;
+import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
 
 import static sync.slamtalk.team.error.TeamErrorResponseCode.TEAM_POST_ALREADY_DELETED;
@@ -22,14 +22,14 @@ public class TeamMatchingService {
     private final TeamMatchingRepository teamMatchingRepository;
 
     public long registerTeamMatching(FromTeamFormDTO dto, long userId){
-        TeamMatchings teamMatchingEntity = new TeamMatchings();
+        TeamMatching teamMatchingEntity = new TeamMatching();
         teamMatchingEntity.createTeamMatching(dto, userId);
-        TeamMatchings resultTeamMatchingEntity = teamMatchingRepository.save(teamMatchingEntity);
+        TeamMatching resultTeamMatchingEntity = teamMatchingRepository.save(teamMatchingEntity);
         return resultTeamMatchingEntity.getTeamMatchingId();
     }
 
     public ToTeamFormDTO getTeamMatching(long teamMatchingId){
-        TeamMatchings teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow(() -> new BaseException(TEAM_POST_NOT_FOUND));
+        TeamMatching teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow(() -> new BaseException(TEAM_POST_NOT_FOUND));
         if(teamMatchingEntity.getIsDeleted()){
             throw new BaseException(TEAM_POST_ALREADY_DELETED);
         }
@@ -39,12 +39,12 @@ public class TeamMatchingService {
     }
 
     public ApiResponse updateTeamMatching(long teamMatchingId, FromTeamFormDTO fromTeamFormDTO){
-        TeamMatchings teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow();
+        TeamMatching teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow();
         teamMatchingEntity.updateTeamMatching(fromTeamFormDTO);
         return ApiResponse.ok();
     }
 
-    public ApiResponse deleteTeamMatching(long teamMatchingId, TeamMatchings teamMatchingEntity){
+    public ApiResponse deleteTeamMatching(long teamMatchingId, TeamMatching teamMatchingEntity){
         teamMatchingEntity.delete();
         return ApiResponse.ok();
     }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
-  CANCEL -> CANCELED로 수정함.
-  팀 신청자 엔티티 생성
-  팀매칭 목록 조회 기능 및 해당 팀매칭 게시글에 신청하기 기능 구현
-  dto 관련 리팩토링 진행
-  엔티티 클래스명 수정(TeamMatchings -> TeamMatching)
-  해당 기능 api 기본적인 요청 테스트 완료
closed #95 
