### PR TITLE
#80 유저 마이페이지  사용자의 level 및 팀 매칭 완료 횟수를 보여주는 로직 추가

### DIFF
--- a/src/main/java/sync/slamtalk/common/GlobalRestControllerAdvice.java
+++ b/src/main/java/sync/slamtalk/common/GlobalRestControllerAdvice.java
@@ -3,6 +3,7 @@ package sync.slamtalk.common;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -41,4 +42,14 @@ public class GlobalRestControllerAdvice {
         log.debug("Exception cathced in RestControllerAdvice:{}",e.getMessage());
         return ApiResponse.fail(e.getMessage());
     }
+
+    // enum 타입 클라이언트가 잘못 요청 했을 경우 발생하는 exception
+    // HttpMessageNotReadableException
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ApiResponse<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e){
+        log.debug("Exception cathced in RestControllerAdvice:{}",e.getMessage());
+        return ApiResponse.fail(e.getMessage());
+    }
+
 }

--- a/src/main/java/sync/slamtalk/mate/repository/MatePostRepository.java
+++ b/src/main/java/sync/slamtalk/mate/repository/MatePostRepository.java
@@ -1,5 +1,6 @@
 package sync.slamtalk.mate.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,13 @@ public interface MatePostRepository extends JpaRepository<MatePost, Long> {
 
     //메이트찾기 목록 조회를 위한 메소드
     List<MatePost> findByCreatedAtLessThanAndIsDeletedNotOrderByCreatedAtDesc(LocalDateTime createdAt, boolean isDeleted, Pageable pageable);
+
+    /* 레벨 시스템 : 모집상태가 완료된 사용자의 개수를 반환하는 메서드 */
+    @Query("select count(*) " +
+            "from MatePost m " +
+            "join Participant p on m.matePostId = p.matePost.matePostId " +
+            "where p.participantId = :userId " +
+            "and m.recruitmentStatus = 'COMPLETED' " +
+            "and p.applyStatus = 'ACCEPTED'")
+    Long findMateCompleteParticipationCount(@Param("userId") Long userId);
 }

--- a/src/main/java/sync/slamtalk/security/oauth2/OAuthAttributes.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/OAuthAttributes.java
@@ -91,7 +91,6 @@ public class OAuthAttributes {
                 .password(UUID.randomUUID().toString())
                 .nickname(newNickname)
                 .role(UserRole.USER)
-                .levelScore(0L)
                 .socialType(socialType)
                 .socialId(oauth2UserInfo.getId())
                 .imageUrl(oauth2UserInfo.getImageUrl())

--- a/src/main/java/sync/slamtalk/user/dto/UserDetailsInfoResponseDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserDetailsInfoResponseDto.java
@@ -26,25 +26,34 @@ public class UserDetailsInfoResponseDto {
     /* 정보 수집 부분 */
     private UserBasketballSkillLevelType basketballSkillLevel;
     private UserBasketballPositionType basketballPosition;
+    private Long level = 0L;
     private Long levelScore = 0L;
     private Long mateCompleteParticipationCount = 0L;
     private Long teamMatchingCompleteParticipationCount = 0L;
 
+
     /**
      * 나의 프로필 조회 시 필요한 정보를 반환하는 생성자
+     *
      * @param user db에서 조회한 user 객체
+     * @param mateCompleteParticipationCount 메이트 참여완료 횟수
      * @return UserDetailsInfoResponseDto 개인정보 포함된 정보
-     * */
-    public static UserDetailsInfoResponseDto generateMyProfile(User user){
-        return UserDetailsInfoResponseDto.builder()
+     */
+    public static UserDetailsInfoResponseDto generateMyProfile(
+            User user,
+            long level,
+            long levelScore,
+            long mateCompleteParticipationCount
+    ){ return UserDetailsInfoResponseDto.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
                 .imageUrl(user.getImageUrl())
                 .selfIntroduction(user.getSelfIntroduction())
                 .basketballSkillLevel(user.getBasketballSkillLevel())
                 .basketballPosition(user.getBasketballPosition())
-                .levelScore(user.getLevelScore())
-                .mateCompleteParticipationCount(0L)
+                .level(levelScore)
+                .levelScore(levelScore)
+                .mateCompleteParticipationCount(mateCompleteParticipationCount)
                 .teamMatchingCompleteParticipationCount(0L)
                 .email(user.getEmail())
                 .socialType(user.getSocialType())
@@ -54,19 +63,26 @@ public class UserDetailsInfoResponseDto {
 
     /**
      * 상대방 프로필 조회 시 필요한 정보를 반환하는 생성자
-     * @param user db에서 조회한 user 객체
+     *
+     * @param user                           db에서 조회한 user 객체
+     * @param mateCompleteParticipationCount
      * @return UserDetailsInfoResponseDto 개인정보 제외된 정보
-     * */
-    public static UserDetailsInfoResponseDto generateOtherUserProfile(User user){
-        return UserDetailsInfoResponseDto.builder()
+     */
+    public static UserDetailsInfoResponseDto generateOtherUserProfile(
+            User user,
+            long level,
+            long levelScore,
+            long mateCompleteParticipationCount
+    ) { return UserDetailsInfoResponseDto.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
                 .imageUrl(user.getImageUrl())
                 .selfIntroduction(user.getSelfIntroduction())
                 .basketballSkillLevel(user.getBasketballSkillLevel())
                 .basketballPosition(user.getBasketballPosition())
-                .levelScore(user.getLevelScore())
-                .mateCompleteParticipationCount(0L)
+                .levelScore(levelScore)
+                .level(level)
+                .mateCompleteParticipationCount(mateCompleteParticipationCount)
                 .teamMatchingCompleteParticipationCount(0L)
                 .build();
 

--- a/src/main/java/sync/slamtalk/user/dto/UserSignUpRequestDto.java
+++ b/src/main/java/sync/slamtalk/user/dto/UserSignUpRequestDto.java
@@ -43,7 +43,6 @@ public class UserSignUpRequestDto {
                  .password(this.getPassword())
                  .nickname(this.getNickname())
                  .role(UserRole.USER)
-                 .levelScore(0L)
                  .socialType(SocialType.LOCAL)
                  .firstLoginCheck(true)
                  .build();

--- a/src/main/java/sync/slamtalk/user/entity/User.java
+++ b/src/main/java/sync/slamtalk/user/entity/User.java
@@ -66,14 +66,9 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "is_alarm_set")
     private String isAlarmSet;
 
-    /* 레벨 시스템 기능 */
-    @Column(name = "level_score", nullable = false)
-    private Long levelScore = 0L;
-
     /* 연관 관계 매핑 */
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserChatRoom> userChatRooms = new ArrayList<>();
-
 
 /*
     //todo : 동수님 연관관계 매핑 부분

--- a/src/test/java/sync/slamtalk/mate/repository/MatePostRepositoryTest.java
+++ b/src/test/java/sync/slamtalk/mate/repository/MatePostRepositoryTest.java
@@ -1,0 +1,69 @@
+package sync.slamtalk.mate.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.DialectOverride;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import sync.slamtalk.mate.entity.*;
+import sync.slamtalk.user.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class MatePostRepositoryTest {
+    @Autowired
+    private MatePostRepository matePostRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Test
+    @DisplayName("메이트 참여 완료된 사용자 개수 세는 레포")
+    @Disabled
+    void findMateCompleteParticipationCount() {
+        MatePost matePost = new MatePost(
+                1L,
+                1L, // 추후 유저 엔티티로 변환될 수 있음.
+                "locationDetail",
+                "title",
+                "content",
+                RecruitedSkillLevelType.HIGH,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                1L,
+                RecruitmentStatusType.COMPLETED,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                new ArrayList<>());
+        MatePost matepost = matePostRepository.save(matePost);
+        Participant participant = new Participant(
+                1L,
+                matepost,
+                1L,
+                "nickname",
+                ApplyStatusType.ACCEPTED,
+                PositionType.CENTER,
+                SkillLevelType.HIGH);
+
+        participantRepository.save(participant);
+        
+        Long mateCompleteParticipationCount = matePostRepository.findMateCompleteParticipationCount(1L);
+        Assertions.assertEquals(mateCompleteParticipationCount, 1L);
+    }
+}


### PR DESCRIPTION
## 📝 #80  사용자의 level 및 팀 매칭 완료 횟수를 보여주는 로직 추가
- [x] ExceptionHandler 추가
  - controller에서 dto로 enum을 받고 있을때 enum 에 존재하지 않는 문자열을 받을 때 서버가 던지는 HttpMessageNotReadableException 을 400에러로 커스텀

- [x] 모집상태가 완료된 사용자의 개수를 반환하는 메서드 개발
- [x] 유저 마이페이지에 사용자의 level 및 팀 매칭 완료 횟수를 보여주는 로직 추가

## 💬 리뷰 요구사항 (공유 파일 수정 내역)
- GlobalRestControllerAdvice.java 추가 
- User 엔티티 수정
- MatePostRepository 코드 추가 되었습니다

## MERGE 되면 할 일 (봉승)
- feat/99-info 충돌해결하고 pr 날리기

resolved : #80
