### PR TITLE
#110 feat : Naver, Google 소셜 로그인 구현

### DIFF
--- a/src/main/java/sync/slamtalk/security/oauth2/OAuthAttributes.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/OAuthAttributes.java
@@ -3,7 +3,9 @@ package sync.slamtalk.security.oauth2;
 
 import lombok.Builder;
 import lombok.Getter;
+import sync.slamtalk.security.oauth2.userinfo.GoogleOAuth2UserInfo;
 import sync.slamtalk.security.oauth2.userinfo.KakaoOAuth2UserInfo;
+import sync.slamtalk.security.oauth2.userinfo.NaverOAuth2UserInfo;
 import sync.slamtalk.security.oauth2.userinfo.OAuth2UserInfo;
 import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
@@ -43,15 +45,15 @@ public class OAuthAttributes {
             Map<String, Object> attributes
     ) {
 
-/*        if (socialType == SocialType.NAVER) {
+        if (socialType == SocialType.NAVER) {
             return ofNaver(userNameAttributeName, attributes);
-        }*/
+        }
         if (socialType == SocialType.KAKAO) {
             return ofKakao(userNameAttributeName, attributes);
         }
-/*        if(socialType == SocialType.GOOGLE){
+        if(socialType == SocialType.GOOGLE){
             return ofGoogle(userNameAttributeName, attributes);
-        }*/
+        }
 
         // 지원하지 않는 SocialType이 들어온 경우 예외를 발생시킵니다.
         throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다: " + socialType);
@@ -64,7 +66,7 @@ public class OAuthAttributes {
                 .build();
     }
 
-/*    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
                 .nameAttributeKey(userNameAttributeName)
                 .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
@@ -76,7 +78,7 @@ public class OAuthAttributes {
                 .nameAttributeKey(userNameAttributeName)
                 .oauth2UserInfo(new NaverOAuth2UserInfo(attributes))
                 .build();
-    }*/
+    }
 
     /**
      * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태

--- a/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
@@ -29,7 +29,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private final UserRepository userRepository;
     private final NicknameService nicknameService;
 
-//    private static final String NAVER = "naver";
+    private static final String NAVER = "naver";
     private static final String KAKAO = "kakao";
 
     @Override
@@ -73,13 +73,13 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private SocialType getSocialType(String registrationId) {
-/*        if(NAVER.equals(registrationId)) {
+        if(NAVER.equals(registrationId)) {
             return SocialType.NAVER;
-        }*/
-//        if(KAKAO.equals(registrationId)) {
+        }
+        if(KAKAO.equals(registrationId)) {
             return SocialType.KAKAO;
-//        }
-/*        return SocialType.GOOGLE;*/
+        }
+        return SocialType.GOOGLE;
     }
 
     /**

--- a/src/main/java/sync/slamtalk/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -25,6 +25,6 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getEmail() {
-        return null;
+        return (String) attributes.get("email");
     }
 }

--- a/src/main/java/sync/slamtalk/security/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -42,6 +42,11 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getEmail() {
-        return null;
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("email");
     }
 }


### PR DESCRIPTION
## 📝 feat : Naver, Google 소셜 로그인 구현

- 구글 OAuth 2.0 을 통해서 소셜 로그인 구현하기
- 네이버 OAuth 2.0 을 통해서 소셜 로그인 구현하기


## 💬 리뷰 요구사항
- application-oauth.yml 파일이 수정되었습니다!
