### PR TITLE
#88,91 s3bucket 이미지 업로드 검증메서드 추가, 이미지 삭제수정

### DIFF
--- a/src/main/java/sync/slamtalk/common/ErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/common/ErrorResponseCode.java
@@ -32,11 +32,18 @@ public enum ErrorResponseCode implements ResponseCodeDetails {
     /* s3 bucket 에러*/
 
     // 이미지 찾을 수 없을 때
-    S3_BUCKET_NOT_FOUND(SC_BAD_REQUEST,6000,"Image is null"),
+    S3_BUCKET_NOT_FOUND(SC_BAD_REQUEST,6000,"image is null"),
     // 이미지 업로드 실패
-    S3_BUCKET_CANNOT_UPLOAD(SC_BAD_REQUEST,6001,"failed Upload"),
+    S3_BUCKET_CANNOT_UPLOAD(SC_BAD_REQUEST,6001,"failed upload"),
     // 이미지 삭제 실패
-    S3_BUCKET_CANNOT_DELETE(SC_BAD_REQUEST,6002,"failed Delete");
+    S3_BUCKET_CANNOT_DELETE(SC_BAD_REQUEST,6002,"failed delete"),
+    // 지원 하지 않은 확장자 파일 업로드 시
+    S3_BUCKET_INVALID_EXTENSION(SC_BAD_REQUEST,6003,"invalid extension"),
+    // 파일 크기 제한 초과 시
+    S3_BUCKET_EXCEEDED_CAPACITY(SC_BAD_REQUEST,6004,"capacity exceeded")
+
+
+    ;
 
     private final int code;
     private int status;

--- a/src/main/java/sync/slamtalk/common/s3bucket/FileUploadController.java
+++ b/src/main/java/sync/slamtalk/common/s3bucket/FileUploadController.java
@@ -3,6 +3,7 @@ package sync.slamtalk.common.s3bucket;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/s3")
 @RequiredArgsConstructor
+@Slf4j
 public class FileUploadController {
 /*
    Controller Sample
@@ -32,6 +34,7 @@ public class FileUploadController {
     )
     public ApiResponse<String> uploadFile(@RequestParam("file")MultipartFile multipartFile){
         String loadFile= awsS3Service.uploadFile(multipartFile);
+        log.debug("====> capacity:{}",multipartFile.getSize());
         return ApiResponse.ok(loadFile,"업로드 완료");
     }
 

--- a/src/main/java/sync/slamtalk/common/s3bucket/repository/AwsS3RepositoryImpl.java
+++ b/src/main/java/sync/slamtalk/common/s3bucket/repository/AwsS3RepositoryImpl.java
@@ -22,14 +22,14 @@ import java.util.List;
 @Service
 public class AwsS3RepositoryImpl implements AwsS3Repository{
 
-    private final S3Client s3Client;
+        private final S3Client s3Client;
 
-    @Value("${spring.cloud.aws.s3.bucket}")
-    private String bucketName;
+        @Value("${spring.cloud.aws.s3.bucket}")
+        private String bucketName;
 
-    @Value("${s3.bucket.base.url}")
-    private String s3BucketBaseUrl;
-    private static final long MAX_FILE_SIZE = 1 * 1024 * 1024;
+        @Value("${s3.bucket.base.url}")
+        private String s3BucketBaseUrl;
+        private static final long MAX_FILE_SIZE = 1 * 1024 * 1024;
 
 
     @Override

--- a/src/main/java/sync/slamtalk/common/s3bucket/repository/AwsS3RepositoryImpl.java
+++ b/src/main/java/sync/slamtalk/common/s3bucket/repository/AwsS3RepositoryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -26,6 +27,9 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Value("${s3.bucket.base.url}")
+    private String s3BucketBaseUrl;
+    private static final long MAX_FILE_SIZE = 1 * 1024 * 1024;
 
 
     @Override
@@ -45,6 +49,14 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
                     .contentLength(multipartFile.getSize()) // 사이즈 설정
                     .key(fileName)
                     .build();
+
+            // jpeg,png 확장자인지 검증
+            extensionValidator(multipartFile);
+
+            // 용량 초과 하지 않는지 검증
+            if(!capacityValidator(multipartFile)){
+                throw new BaseException(ErrorResponseCode.S3_BUCKET_EXCEEDED_CAPACITY);
+            }
 
             // 파일 업로드 요청
             RequestBody requestBody = RequestBody.fromBytes(multipartFile.getBytes()); // 파일 데이터를 바이트 배열로 변환하여 RequestBody 객체를 생성
@@ -76,6 +88,15 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
         // 특정
         String fileName = getFileName(multipartFile,folder);
         try{
+
+            // jpeg,png 확장자인지 검증
+            extensionValidator(multipartFile);
+
+            // 용량 초과 하지 않는지 검증
+            if(!capacityValidator(multipartFile)){
+                throw new BaseException(ErrorResponseCode.S3_BUCKET_EXCEEDED_CAPACITY);
+            }
+
             // multipartFile로부터 데이터를 읽은 후 PutObjectRequest 객체를 생성
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName) // 저장할 버킷명
@@ -110,6 +131,15 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
 
         multipartFiles.forEach(multipartFile -> {
             String uploadFile = uploadFile(multipartFile);
+
+            // jpeg,png 확장자인지 검증
+            extensionValidator(multipartFile);
+
+            // 용량 초과 하지 않는지 검증
+            if(!capacityValidator(multipartFile)){
+                throw new BaseException(ErrorResponseCode.S3_BUCKET_EXCEEDED_CAPACITY);
+            }
+
             urlList.add(uploadFile);
         });
         return urlList;
@@ -123,6 +153,15 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
 
         multipartFiles.forEach(multipartFile -> {
             String uploadFile = uploadFileToFolder(multipartFile,folder);
+
+            // jpeg,png 확장자인지 검증
+            extensionValidator(multipartFile);
+
+            // 용량 초과 하지 않는지 검증
+            if(!capacityValidator(multipartFile)){
+                throw new BaseException(ErrorResponseCode.S3_BUCKET_EXCEEDED_CAPACITY);
+            }
+
             urlList.add(uploadFile);
         });
         return urlList;
@@ -131,13 +170,16 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
 
     @Override
     // 저장된 파일 지우기
-    // TODO 권한 확인 후 수정
     public String deleteFile(String fileName) {
+
+        // key값만 추출
+        String targetKey = extractObjectKey(fileName);
+
         try {
             // 파일 삭제 요청 생성
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(fileName)
+                    .key(targetKey)
                     .build();
 
             // S3 클라이언트를 사용하여 파일 삭제 요청 실행
@@ -168,4 +210,38 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
         }
         return CommonUtils.buildFileName(multipartFile.getOriginalFilename(),folderName);
     }
+
+    // 올바른 파일 확장자인지 검증
+    // jpeg, png 이미지 파일 확장자만 가능
+    private void extensionValidator(MultipartFile multipartFile){
+        String contentType = multipartFile.getContentType();
+
+        // 확장자가 jpeg,png 인 파일들만 받아서 처리
+        if(ObjectUtils.isEmpty(contentType) || (!contentType.contains("image/jpeg") && !contentType.contains("image/png"))){
+            throw new BaseException(ErrorResponseCode.S3_BUCKET_INVALID_EXTENSION);
+        }
+    }
+
+    // 1MB 가 초과하지 않는 파일인지 검증
+    private boolean capacityValidator(MultipartFile multipartFile){
+        if(multipartFile.getSize()<=MAX_FILE_SIZE){
+            return true;
+        }
+        return  false;
+    }
+
+
+    // 객체 key 값 추출
+    // 파라미터로 이미지 url
+    private String extractObjectKey(String s3objectUrl){
+        if(s3objectUrl!=null && s3objectUrl.startsWith(s3BucketBaseUrl)){
+            log.debug("extractkey:{}",s3objectUrl.substring(s3BucketBaseUrl.length()));
+            return s3objectUrl.substring(s3BucketBaseUrl.length());
+        }
+        return null;
+    }
+
+
+
+
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- [x] 이미지 확장자 (png,jpeg) 외에 다른 확장자 파일 업로드 못하게함
- [x] 1MB 초과 시 파일 업로드 못하게함
- [x] 파일 삭제 메서드 완료


## 💬 리뷰 요구사항 (선택)
- 👀 같이 리뷰 필요 (선택)
> s3bucket 에서 객체 key를 전체 url로  잘못설정해서 제대로 삭제가 안되고있었습니다. 파일을 삭제할 때는 객체 '키'를 이용해서 삭제해야 합니다. 
> 예외처리 수정이 필요합니다 🥲 수정 완료하면 말씀드릴게요! 그때 리뷰해주시면 좋을 거 같습니다. 이점 양해부탁드립니다!


closed #88 #91 
