### PR TITLE
#141 refactor : 소셜로그인 완료 시 리다이렉트 url 변경

### DIFF
--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -67,7 +67,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         setRefreshTokenCookie(response, refreshToken);
 
-        response.sendRedirect("http://localhost:3000?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
+        response.sendRedirect("http://localhost:3000/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
 
         // 최초 정보수집을 위해 jwtTokenResponseDto의 firstLoginCheck은 true 로 반환, 이후는 false 로 반환하기 위한 로직
         if(Boolean.TRUE.equals(user.getFirstLoginCheck())) user.updateFirstLoginCheck();


### PR DESCRIPTION
## 📝 refactor : 소셜로그인 완료 시 리다이렉트 url 변경

- 기존 : localhost:3000 테스트 용 서버로 전송
- 변경 : localhost:3000/social-login 으로 전송 하기!
- 변경 사유 : 프론트 측에서 accessToken 재발급 요청을 보내기 위해서 다음과 같이 url을 변경하였습니다!
- 소셜 로그인 시에 서버 측에서 리다이렉트를 시켜버리면 쿠키와 파라미터 밖에 전달 되지않아서 이렇게 수정하게되었습니다!

