### PR TITLE
#144 feat : setUserListChatRoom 메서드 구현

### DIFF
--- a/src/main/java/sync/slamtalk/chat/service/ChatService.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatService.java
@@ -55,6 +55,9 @@ public interface ChatService {
     // 특정방을 나갈 때 userChatRoom softDelete
     Optional<UserChatRoom> exitRoom(Long userId, Long chatRoomId);
 
+    // 팀 매칭/상대팀 매칭 완료 시 채팅방 생성후 chatRoomId와 매칭에 참여한 userId를 List 로 입력 받아 UserChatRoom에 저장 하는 메서드
+    void setUserListChatRoom(Long chatRoomId, List<Long> usersId);
+
 
 
 

--- a/src/main/java/sync/slamtalk/user/entity/User.java
+++ b/src/main/java/sync/slamtalk/user/entity/User.java
@@ -192,4 +192,13 @@ public class User extends BaseEntity implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+
+    /**
+     * 테스트용 Id 세팅 하는 메서드
+     * @param id 테스트코드용 userId
+     * */
+    public void testSetUserId(Long id){
+        this.id = id;
+    }
 }

--- a/src/test/java/sync/slamtalk/chat/service/ChatServiceImplTest.java
+++ b/src/test/java/sync/slamtalk/chat/service/ChatServiceImplTest.java
@@ -1,0 +1,80 @@
+package sync.slamtalk.chat.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sync.slamtalk.chat.entity.ChatRoom;
+import sync.slamtalk.chat.entity.RoomType;
+import sync.slamtalk.chat.entity.UserChatRoom;
+import sync.slamtalk.chat.repository.ChatRoomRepository;
+import sync.slamtalk.chat.repository.UserChatRoomRepository;
+import sync.slamtalk.user.UserRepository;
+import sync.slamtalk.user.dto.UserSignUpRequestDto;
+import sync.slamtalk.user.entity.User;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class ChatServiceImplTest {
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserChatRoomRepository userChatRoomRepository;
+
+    @InjectMocks
+    private ChatServiceImpl chatService;
+    @Test
+    @DisplayName("팀매칭 완료 시 UserChatRoom에 User 리스트 추가 테스트")
+    void setUserListChatRoom() {
+        User entity1 = new UserSignUpRequestDto("test1@naver.com", "password", "hi1").toEntity();
+        User entity2 = new UserSignUpRequestDto("test2@naver.com", "password", "hi2").toEntity();
+        User entity3 = new UserSignUpRequestDto("test3@naver.com", "password", "hi3").toEntity();
+
+        entity1.testSetUserId(1L); // 수동으로 ID 설정
+        entity2.testSetUserId(1L); // 수동으로 ID 설정
+        entity3.testSetUserId(1L); // 수동으로 ID 설정
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .id(1L)
+                .name("하이")
+                .roomType(RoomType.TOGETHER)
+                .userChats(new HashSet<>())
+                .build();
+        List<User> userList = List.of(entity1, entity2, entity3);
+        List<UserChatRoom> userChatRooms = userList.stream().map(user -> {
+            // UserChatRoom 생성
+            UserChatRoom userChatRoom = UserChatRoom.builder()
+                    .readIndex(0L) // 초기화
+                    .isFirst(true) // 초기화
+                    .chat(chatRoom)
+                    .user(user)
+                    .build();
+
+            // ChatRoom 에도 userchatRoom 추가
+            chatRoom.addUserChatRoom(userChatRoom);
+            return userChatRoom;
+        }).toList();
+
+        Mockito.when(chatRoomRepository.findById(chatRoom.getId()))
+                .thenReturn(Optional.of(chatRoom));
+        Mockito.when(userRepository.findAllById(List.of(entity1.getId(), entity2.getId(), entity3.getId())))
+                .thenReturn(userList);
+        Mockito.when(userChatRoomRepository.saveAll(Mockito.any(List.class)))
+                .thenReturn(userChatRooms);
+
+
+        chatService.setUserListChatRoom(chatRoom.getId(), List.of(entity1.getId(), entity2.getId(), entity3.getId()));
+
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 팀매칭 / 상대팀 매칭 완료 시 채팅방 생성 후 해당 채팅방 id에 해당하는UserChatRoom에 User 리스트 추가하는 메서드
- 구현 이유 : 매칭 완료 시 참여한 모든 유저가 채팅 리스트에서 해당 채팅이 보여야하기 때문에 구현하였습니다.
- ChatServiceImplTest.java 를 통해서 테스트를 수행하였습니다!
  - 정상적으로 db에 저장되는 로직을 확인하였습니다

resolved : #144 
