### PR TITLE
#137 chat API 수정

### DIFF
--- a/src/main/java/sync/slamtalk/chat/config/ChatInboundInterceptor.java
+++ b/src/main/java/sync/slamtalk/chat/config/ChatInboundInterceptor.java
@@ -192,9 +192,14 @@ public class ChatInboundInterceptor implements ChannelInterceptor {
                 String nickname = extractNickname(messageContent);
                 log.debug("extract message nickname:{}",nickname);
 
+                // 메세지 보낸 유저의 아이디 추출
+                String uid = extractUserId(messageContent);
+                Long userid = Long.parseLong(uid);
+
                 if (content != null) {
                     ChatMessageDTO chatMessageDTO = ChatMessageDTO.builder()
                             .roomId(roomId.toString())
+                            .senderId(userid)
                             .content(content)
                             .senderNickname(nickname)
                             .timestamp(LocalDateTime.now().toString())
@@ -340,6 +345,19 @@ public class ChatInboundInterceptor implements ChannelInterceptor {
     }
 
 
+    // 채팅 유저 아이디 추출
+    private String extractUserId(String json){
+        try{
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode rootNode = mapper.readTree(json);
+            if(rootNode.has("senderId")){
+                return rootNode.get("senderId").toString();
+            }
+        }catch (Exception e){
+            throw new RuntimeException(e.getMessage());
+        }
+        return null;
+    }
 
 
     // 사용자 채팅방에 추가

--- a/src/main/java/sync/slamtalk/chat/dto/Request/ChatCreateDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Request/ChatCreateDTO.java
@@ -1,15 +1,21 @@
 package sync.slamtalk.chat.dto.Request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.io.Serializable;
+import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값이 아닌 필드만 포함
 public class ChatCreateDTO implements Serializable {
+    private Long creator_id; // 생성자 아이디
+    private List<Long> participants; // 참여자 아이디 , 알림을 주어야 하니
     private String roomType; // 1:1 이냐 단체방 이냐
+    private Long basket_ball_id;
     private String name; // 채팅방 이름
 }

--- a/src/main/java/sync/slamtalk/chat/dto/Request/ChatMessageDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Request/ChatMessageDTO.java
@@ -3,6 +3,7 @@ package sync.slamtalk.chat.dto.Request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Null;
 import lombok.*;
 
 import java.io.Serializable;
@@ -20,10 +21,15 @@ public class ChatMessageDTO implements Serializable {
     @Nullable
     private String roomId; // 채팅방 아이디(채팅방 식별자)
     @Nullable
+    private Long senderId; // 메세지를 보낸 사용자의 아이디
+    @Nullable
     private String senderNickname; // 메세지를 보낸 사용자의 닉네임 -> 채팅방에 표시될
+    @Nullable
+    private String imgUrl; // 메세지를 보낸 사용자의 프로필
     @Nullable
     private String content; // 메세지 내용
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private String timestamp; // 메세지를 보낸 시간
+
 
 }

--- a/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
@@ -14,16 +14,22 @@ import java.io.Serializable;
 public class ChatRoomDTO implements Serializable {
     // 채팅방 고유 아이디
     private String roomId;
+    // 채팅방 타입
+    private String roomType;
     // 채팅방 상대방 아이디
     private String partnerId;
     // 채팅방 이름
     private String name;
+    // 채팅방 이미지
+    private String imgUrl;
     // 채팅방 마지막 메세지
-    private String last_message;
+    private String lastMessage;
+    // 농구장 아이디
+    private Long courtId;
 
 
     // 채팅방 마지막 메세지 업데이트
-    public void setLast_message(String last_message) {
-        this.last_message = last_message;
+    public void setLast_message(String lastMessage) {
+        this.lastMessage = lastMessage;
     }
 }

--- a/src/main/java/sync/slamtalk/chat/entity/ChatRoom.java
+++ b/src/main/java/sync/slamtalk/chat/entity/ChatRoom.java
@@ -3,6 +3,7 @@ package sync.slamtalk.chat.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import sync.slamtalk.common.BaseEntity;
+import sync.slamtalk.map.entity.BasketballCourt;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -19,10 +20,17 @@ public class ChatRoom extends BaseEntity {
     @Column(name="chatroom_id") // 식별 아이디
     private Long id;
 
+
+//    @OneToOne(mappedBy = "chatRoom", fetch = FetchType.LAZY)
+//    private BasketballCourt basketballCourt;
+
+
     @Column(name = "chatroom_type",nullable = false)
+    @Enumerated(EnumType.STRING)
     private RoomType roomType; // 다이렉트메세지, 농구장, 같이해요, 팀매칭
 
-    @Column(name = "chatroom_name",nullable = false)
+
+    @Column(name = "chatroom_name")
     private String name; // 방 제목
 
 
@@ -36,5 +44,11 @@ public class ChatRoom extends BaseEntity {
         this.userChats.add(userChatRoom);
         userChatRoom.setChat(this);
     }
+
+
+//    // chatroom 에 basketball 설정
+//    public void setBasketballCourt(BasketballCourt basketballCourt) {
+//        this.basketballCourt = basketballCourt;
+//    }
 
 }

--- a/src/main/java/sync/slamtalk/chat/entity/Messages.java
+++ b/src/main/java/sync/slamtalk/chat/entity/Messages.java
@@ -18,8 +18,12 @@ public class Messages extends BaseEntity {
     private Long id; // 식별 아이디
 
     // 작성자
-    @Column(name = "writer")
-    private String writer;
+    @Column(name = "sender_nickname")
+    private String senderNickname;
+
+    // 작성자 아이디
+    @Column(name = "sender_id")
+    private Long senderId;
 
     // 메세지(내용)
     @Column(name = "content")

--- a/src/main/java/sync/slamtalk/chat/entity/UserChatRoom.java
+++ b/src/main/java/sync/slamtalk/chat/entity/UserChatRoom.java
@@ -28,6 +28,18 @@ public class UserChatRoom extends BaseEntity {
     @JoinColumn(name = "chatroom_id",nullable = false)
     private ChatRoom chat;
 
+    // 채팅방 타입
+    @Enumerated(EnumType.STRING)
+    @Column(name = "chatroom_type")
+    private RoomType roomType;
+
+    @Column(name = "chatroom_source")
+    private Long source; // 1:1채팅의 경우 상대방 userId, 농구장채팅인 경우 court_id;
+
+
+    @Column(name = "chatroom_img")
+    private String imageUrl; // 채팅리스트에 뜨는 이미지
+
 
     // 사용자가 마지막으로 읽은 메세지의 아이디 값 저장
     @Column(name = "read_index")

--- a/src/main/java/sync/slamtalk/chat/repository/UserChatRoomRepository.java
+++ b/src/main/java/sync/slamtalk/chat/repository/UserChatRoomRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
 
     // UserChatRoom 테이블에서 chatRoomId 로 데이터 가져오기
-    Optional<UserChatRoom> findByChat_Id(Long chatRoomId);
+    List<UserChatRoom> findByChat_Id(Long chatRoomId);
 
 
     // 특정 User_Id에 해당하는 모든 UserChatRoom 엔터티를 찾는 메서드


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 채팅내역에 응답에 senderId, imgUrl 추가
- 채팅리스트에서 농구장 에서 형성된 채팅방이면 프로필을 눌렀을 때 농구장 정보로 이동할 수 있도록 id 추가,
1:1 인 경우에는 상대방 프로필 눌렀을 때 상대방 마이페이지에 대한 정보를 주기 위해 userId 추가
- 채팅리스트 응답에 roomType 추가
- roomtype @Enumerated 어노테이션 추가하여 ENUM 클래스 값으로 테이블 값 표시
- chatcreate (채팅방생성요청) 요청 api 수정



## 💬 리뷰 요구사항 (선택)
- 👀 같이 리뷰 필요
   - Message entity 스키마 변경하여서 db 초기화하고 다시 생성해야할거 같은데 혹시 수작업으로 넣으신 데이터가 많을까요?ㅠㅠ
   db초기화 안하고 실행시키면 아마 에러가 날거같은데 이 부분은 이야기 나누어봐야할거같습니다..🥲