### PR TITLE
#158,#166 채팅방 입장 전 로직 유형별 수정, 중복생성과 접속 유형 검증 메서드 추가

### DIFF
--- a/src/main/java/sync/slamtalk/chat/controller/ChatController.java
+++ b/src/main/java/sync/slamtalk/chat/controller/ChatController.java
@@ -55,7 +55,6 @@ public class ChatController {
     }
 
     // 채팅 참여
-    // TODO 페이징정책 확정되면 다시 수정해야함
     @PostMapping("/api/chat/participation")
     @Operation(
             summary = "새로운 채팅 내역 조회",

--- a/src/main/java/sync/slamtalk/chat/dto/ChatErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/chat/dto/ChatErrorResponseCode.java
@@ -11,6 +11,8 @@ public enum ChatErrorResponseCode implements ResponseCodeDetails {
     CHAT_FAIL(SC_BAD_REQUEST,4021,"Failed Chatting"),
     CHAT_LIST_NOT_FOUND(SC_NOT_FOUND,4022,"ChatList Not Found"),
     CHAT_ROOM_NOT_FOUND(SC_NOT_FOUND,4023,"ChatRoom Not Found"),
+
+    CHAT_TARGET_NOT_FOUND(SC_NOT_FOUND,4033,"Partners Not Found")
     ;
 
 

--- a/src/main/java/sync/slamtalk/chat/dto/Request/ChatMessageDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Request/ChatMessageDTO.java
@@ -3,11 +3,9 @@ package sync.slamtalk.chat.dto.Request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.Null;
 import lombok.*;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 
 @Getter

--- a/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
@@ -32,4 +32,16 @@ public class ChatRoomDTO implements Serializable {
     public void setLast_message(String lastMessage) {
         this.lastMessage = lastMessage;
     }
+
+    public void updateName(String name){
+        this.name = name;
+    }
+
+    public void updateImgUrl(String imgUrl){
+        this.imgUrl = imgUrl;
+    }
+
+    public void updatecourtId(Long courtId){
+        this.courtId = courtId;
+    }
 }

--- a/src/main/java/sync/slamtalk/chat/entity/ChatRoom.java
+++ b/src/main/java/sync/slamtalk/chat/entity/ChatRoom.java
@@ -21,8 +21,8 @@ public class ChatRoom extends BaseEntity {
     private Long id;
 
 
-//    @OneToOne(mappedBy = "chatRoom", fetch = FetchType.LAZY)
-//    private BasketballCourt basketballCourt;
+    @OneToOne(mappedBy = "chatroom", fetch = FetchType.LAZY)
+    private BasketballCourt basketballCourt;
 
 
     @Column(name = "chatroom_type",nullable = false)
@@ -46,9 +46,9 @@ public class ChatRoom extends BaseEntity {
     }
 
 
-//    // chatroom 에 basketball 설정
-//    public void setBasketballCourt(BasketballCourt basketballCourt) {
-//        this.basketballCourt = basketballCourt;
-//    }
+    // chatroom 에 basketball 설정
+    public void setBasketballCourt(BasketballCourt basketballCourt) {
+        this.basketballCourt = basketballCourt;
+    }
 
 }

--- a/src/main/java/sync/slamtalk/chat/entity/UserChatRoom.java
+++ b/src/main/java/sync/slamtalk/chat/entity/UserChatRoom.java
@@ -28,6 +28,12 @@ public class UserChatRoom extends BaseEntity {
     @JoinColumn(name = "chatroom_id",nullable = false)
     private ChatRoom chat;
 
+
+    // 채팅방 이름
+    @Column(name = "chatroom_name")
+    private String name;
+
+
     // 채팅방 타입
     @Enumerated(EnumType.STRING)
     @Column(name = "chatroom_type")
@@ -77,4 +83,5 @@ public class UserChatRoom extends BaseEntity {
     public void updateIsFirst(Boolean isFirst){
         this.isFirst = isFirst;
     }
+
 }

--- a/src/main/java/sync/slamtalk/chat/repository/UserChatRoomRepository.java
+++ b/src/main/java/sync/slamtalk/chat/repository/UserChatRoomRepository.java
@@ -2,6 +2,7 @@ package sync.slamtalk.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import sync.slamtalk.chat.entity.RoomType;
 import sync.slamtalk.chat.entity.UserChatRoom;
 
 import java.util.List;
@@ -20,4 +21,9 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
     // 특정 userId 와 특정 roomId 로 userChatRoom 엔터티 가져오기
     @Query("select m from UserChatRoom m where m.user.id=:userId and m.chat.id=:roomId")
     Optional<UserChatRoom>findByUserChatroom(Long userId, Long roomId);
+
+
+    // 특정 chatRoomName , 특정 chatRoomType 으로 검색
+    @Query("select m from UserChatRoom m where m.user.id=:userId and m.chat.name=:roomName and m.chat.roomType=:roomType")
+    Optional<UserChatRoom>findByUserChatroomExist(Long userId, String roomName, RoomType roomType);
 }

--- a/src/main/java/sync/slamtalk/chat/service/ChatService.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatService.java
@@ -17,10 +17,6 @@ public interface ChatService {
     long createChatRoom(ChatCreateDTO chatCreateDTO);
 
 
-    // 채팅방에 유저 추가
-    Long setUserChatRoom(Long userId, Long ChatRoomId);
-
-
     // 메세지 저장
     void saveMessage(ChatMessageDTO chatMessageDTO);
 
@@ -55,26 +51,6 @@ public interface ChatService {
     // 특정방을 나갈 때 userChatRoom softDelete
     Optional<UserChatRoom> exitRoom(Long userId, Long chatRoomId);
 
-    // 팀 매칭/상대팀 매칭 완료 시 채팅방 생성후 chatRoomId와 매칭에 참여한 userId를 List 로 입력 받아 UserChatRoom에 저장 하는 메서드
-    void setUserListChatRoom(Long chatRoomId, List<Long> usersId);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    Optional<Boolean> isVisitedFirst(Long userId, Long roomId);
 
 }


### PR DESCRIPTION
## 📝 작업 내용

✅ **userchatroom 생성 시기 변경**
    - 기존 : subscribe 이후에 생성
    - 현재 : 농구장채팅방을 제외하고, 채팅방생성시점에 생성

[ 1:1채팅방, 같이해요채팅방, 팀매칭채팅방 ]
> 채팅방 **생성시점**에 userchatroom 에 추가하여 채팅방 생성자 및 참여자들의 chatlist 에서 채팅방 확인이 가능

[ 농구장채팅방 ]
> "농구장코드정보 : 채팅방" 이므로 유저가 채팅방 **접속시점**에 userchatroom 에 추가하여 참여자들의 chatlist 에서 채팅방 확인이 가능


✅ **채팅방 중복 생성 방지**
    - 기존 : 채팅방 생성 시 동일한 상대와 채팅방에도 불구하고 새로운 채팅방이 계속 생성됨
    - 현재 : 채팅방 생성 시 참여자(채팅방 생성자 포함) 모두 생성 요청에 있는 roomType, roomname 으로 userchatroom 에 가지고 있는 지 확인 후 한명이라도 userchatroom 에 존재하지 않으면 새롭게 생성, 모두 동일한 채팅방을 userchatroom 에 가지고 있다면 기존 채팅방 id 반환


✅ **채팅방 첫접속/재접속 검증**
    - 기존 :  ChatIboundInterceptor 에서 메서드 작성 및 호출
    - 현재 :  ChatService 에 검증메서드 추가, STOMP Message Controller 에서 호출
    
[ SEND_ENTER 메세지 프레임 형식 ]
 > roomId, senderId, senderNickname


✅ **농구장과 연관관계 매핑 주석 제거**


- 📢 테이블 필드 추가 및 연관관계 매핑 코드 추가로 인해 서버 DB 초기화가 필요합니다.
- 초기화 이후에는 chatroom, basketball_court 이 두가지 테이블 데이터는 다시 복구해놓을 예정입니다.


closed #158 #166 

