### PR TITLE
#174 feat : 팀매칭/상대팀 매칭 게스트 api 추가하기

### DIFF
--- a/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
+++ b/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
@@ -84,7 +84,12 @@ public class SecurityConfig {
 
                             // 게스트 권환 설정
                             request.requestMatchers(HttpMethod.GET,
-                                    "/api/map/courts/**").permitAll();
+                                    "/api/map/courts/**",
+                                    "/api/mate/read/**",
+                                    "/api/mate/list",
+                                    "/api/match/read/**",
+                                    "/api/match/list"
+                                    ).permitAll();
                             request.requestMatchers("/api/admin").hasRole(UserRole.ADMIN.toString());
                             request.anyRequest().authenticated();
                         }


### PR DESCRIPTION
## 📝 작업 내용

- 아래의 url들을 Spring Security 에서 Authentication 검증을 안하도록 설정하였습니다.
![image](https://github.com/SlamTalk/slam-talk-backend/assets/101985441/5fd41047-475a-4145-bdbd-da30aafa7631)

- jwtFilter에서 위의 url들을 안거치도록 yml 파일을 다음과 같이 수정했습니다.
```
. . .
    /api/mate/read,
    /api/mate/list,
    /api/match/read,
    /api/match/list
```


## 💬 리뷰 요구사항 (선택)
- application.yml 파일에 위의 exclude path가 추가되었습니다.


resolved : #174 
