### PR TITLE
프론트엔드 수정 요청 반영

### DIFF
--- a/src/main/java/sync/slamtalk/mate/service/MatePostService.java
+++ b/src/main/java/sync/slamtalk/mate/service/MatePostService.java
@@ -100,6 +100,7 @@ public class MatePostService {
                 .startTime(post.getStartTime())
                 .endTime(post.getEndTime())
                 .locationDetail(post.getLocation() + " " + post.getLocationDetail())
+                .skillLevel(post.getSkillLevel())
                 .skillLevelList(skillList)
                 .recruitmentStatus(post.getRecruitmentStatus())
                 .positionList(positionList)

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -52,7 +52,7 @@ public class TeamMatchingController {
             description = "팀 매칭 글을 조회하는 api 입니다.",
             tags = {"팀 매칭", "게스트"}
     )
-    @GetMapping("/read/{teamMatchingId}/")
+    @GetMapping("/read/{teamMatchingId}")
     public ApiResponse<ToTeamFormDTO> getTeamMatchingPage(@PathVariable("teamMatchingId") long teamMatchingId){
 
         ToTeamFormDTO dto = teamMatchingService.getTeamMatching(teamMatchingId);

--- a/src/main/java/sync/slamtalk/team/dto/FromTeamFormDTO.java
+++ b/src/main/java/sync/slamtalk/team/dto/FromTeamFormDTO.java
@@ -29,7 +29,7 @@ public class FromTeamFormDTO {
     private String locationDetail;
 
     @NonNull
-    private Integer numberOfMembers;
+    private String numberOfMembers;
 
     @NonNull
     @Enumerated(EnumType.STRING)

--- a/src/main/java/sync/slamtalk/team/dto/ToTeamFormDTO.java
+++ b/src/main/java/sync/slamtalk/team/dto/ToTeamFormDTO.java
@@ -43,10 +43,13 @@ public class ToTeamFormDTO {
     private String locationDetail;
 
     @NonNull
-    private Integer numberOfMembers;
+    private String numberOfMembers;
 
     @NonNull
-    private List<String> skillLevel;
+    private List<String> skillLevelList;
+
+    @NonNull
+    private RecruitedSkillLevelType skillLevel;
 
     @NonNull
     @JsonFormat(pattern = "yyyy-MM-dd")
@@ -69,5 +72,5 @@ public class ToTeamFormDTO {
     private RecruitmentStatusType recruitmentStatusType;
 
     @NonNull
-    private List<ToApplicantDto> teamApplicantsDto;
+    private List<ToApplicantDto> teamApplicants;
 }

--- a/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
@@ -62,7 +62,7 @@ public class TeamMatching extends BaseEntity implements Post {
     private String locationDetail;
 
     @Column(nullable = false)
-    private Integer numberOfMembers;
+    private String numberOfMembers;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -124,7 +124,6 @@ public class TeamMatching extends BaseEntity implements Post {
         return "teammatching{" +
                 "teamMatchingId=" + teamMatchingId +
                 ", writerId=" + writer.getId() +
-                ", opponentId=" + opponent.getId() +
                 ", teamName='" + teamName + '\'' +
                 ", title='" + title + '\'' +
                 ", content='" + content + '\'' +
@@ -175,7 +174,8 @@ public class TeamMatching extends BaseEntity implements Post {
         dto.setWriterId(this.writer.getId());
         dto.setNickname(this.writer.getNickname());
         dto.setLocationDetail(this.locationDetail);
-        dto.setSkillLevel(mapper.toSkillLevelTypeList(this.skillLevel));
+        dto.setSkillLevel(this.skillLevel);
+        dto.setSkillLevelList(mapper.toSkillLevelTypeList(this.skillLevel));
         dto.setScheduledDate(this.scheduledDate);
         dto.setStartTime(this.startTime);
         dto.setEndTime(this.endTime);
@@ -183,7 +183,7 @@ public class TeamMatching extends BaseEntity implements Post {
         dto.setNumberOfMembers(this.numberOfMembers);
         dto.setCreatedAt(this.getCreatedAt());
         dto.setRecruitmentStatusType(this.recruitmentStatus);
-        dto.setTeamApplicantsDto(this.makeApplicantDto());
+        dto.setTeamApplicants(this.makeApplicantDto());
         return dto;
     }
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 팀매칭 게시글 조회 api 주소 변경: api/match/read/{게시글 id}
- 팀매칭 대결 인원 String으로 수정
- skillLevelList, skillLevel 통일
- teamApplicantsDto 에서 teamApplicants로 수정
- 메이트찾기 상세페이지 조회할때 skillLevel 필드 추가

closed #182