### PR TITLE
refactor: 로컬 개발용 회원가입 api 추가했습니다

### DIFF
--- a/src/main/java/sync/slamtalk/user/controller/AuthController.java
+++ b/src/main/java/sync/slamtalk/user/controller/AuthController.java
@@ -83,7 +83,7 @@ public class AuthController {
     @Operation(
             summary = "자체 회원가입 기능",
             description = "자체 회원가입 기능입니다.",
-            tags = {"로그인/회원가입"}
+            tags = {"백엔드 전용 api"}
     )
     public ApiResponse<String> testSignUp(
             @RequestBody UserSignUpReq userSignUpReqDto,

--- a/src/main/java/sync/slamtalk/user/controller/AuthController.java
+++ b/src/main/java/sync/slamtalk/user/controller/AuthController.java
@@ -74,6 +74,25 @@ public class AuthController {
     }
 
     /**
+     * 회원 가입 api
+     * @param  userSignUpReqDto
+     *
+     * @return  회원가입 성공
+     * */
+    @PostMapping("/test/sign-up")
+    @Operation(
+            summary = "자체 회원가입 기능",
+            description = "자체 회원가입 기능입니다.",
+            tags = {"로그인/회원가입"}
+    )
+    public ApiResponse<String> testSignUp(
+            @RequestBody UserSignUpReq userSignUpReqDto,
+            HttpServletResponse response) {
+        authService.testSignUp(userSignUpReqDto, response);
+        return ApiResponse.ok();
+    }
+
+    /**
      * 리프래쉬 토큰 재발급 api
      * @param request
      * @param response

--- a/src/main/java/sync/slamtalk/user/service/AuthService.java
+++ b/src/main/java/sync/slamtalk/user/service/AuthService.java
@@ -99,14 +99,12 @@ public class AuthService {
             HttpServletResponse response
     ) {
 
-/*
-        TODO : 운영환경에서 주석 해체 필요
         // 이메일 인증된 사용자인지 판별 하는 로직
         String isAuth = redisService.getData(userSignUpReqDto.getEmail());
         if(isAuth == null || !isAuth.equals("OK")){
             log.debug("이메일 인증을 하지 않았습니다!");
             throw new BaseException(UserErrorResponseCode.UNVERIFIED_EMAIL);
-        }*/
+        }
         // 삭제된 유저인지 검증
         checkAlreadyCancelUser(userSignUpReqDto);
         // 중복 이메일 검증
@@ -119,10 +117,28 @@ public class AuthService {
 
         userRepository.save(user);
 
-/*
-        TODO : 운영환경에서 주석 해체 필요
         // 레디스 이메일 인증한 유저 삭제하기
-        redisService.deleteData(userSignUpReqDto.getEmail());*/
+        redisService.deleteData(userSignUpReqDto.getEmail());
+
+        login(new UserLoginReq(userSignUpReqDto.getEmail(), userSignUpReqDto.getPassword()), response);
+    }
+
+    /**
+     * 로컬 개발용 회원가입 검증 및 회원가입 로직
+     *
+     * @param userSignUpReqDto UserSignUpRequestDto
+     * @param response HttpServletResponse
+     * @return JwtTokenResponseDto
+     */
+    @Transactional
+    public void testSignUp(
+            UserSignUpReq userSignUpReqDto,
+            HttpServletResponse response
+    ) {
+        User user = userSignUpReqDto.toEntity();
+        user.passwordEncode(passwordEncoder);
+
+        userRepository.save(user);
 
         login(new UserLoginReq(userSignUpReqDto.getEmail(), userSignUpReqDto.getPassword()), response);
     }


### PR DESCRIPTION
## 📝 작업 내용

- 백엔드 개발용으로 이메일 검증 없이 회원가입을 이용할 수 있도록 /api/test/sign-up을 추가하였습니다.


## 💬 리뷰 요구사항 (선택)
- 기존 /api/sign-up 대신에 /api/test/sign-up을 사용해주세요!

resolved : #178 