### PR TITLE
dto 필드명 수정

### DIFF
--- a/src/main/java/sync/slamtalk/mate/dto/MatePostToDto.java
+++ b/src/main/java/sync/slamtalk/mate/dto/MatePostToDto.java
@@ -45,7 +45,7 @@ public class MatePostToDto {
 
     private List<PositionListDTO> positionList = new ArrayList<>();
     private RecruitedSkillLevelType skillLevel;
-    private List<String> skillList = new ArrayList<>();
+    private List<String> skillLevelList = new ArrayList<>();
     private List<FromParticipantDto> participants = new ArrayList<>();
 
 }

--- a/src/main/java/sync/slamtalk/mate/mapper/EntityToDtoMapper.java
+++ b/src/main/java/sync/slamtalk/mate/mapper/EntityToDtoMapper.java
@@ -168,7 +168,7 @@ public class EntityToDtoMapper {
 
 
         MatePostToDto resultDto = new MatePostToDto();
-        resultDto.setSkillList(toSkillLevelTypeList(dto.getSkillLevel()));
+        resultDto.setSkillLevelList(toSkillLevelTypeList(dto.getSkillLevel()));
         resultDto.setWriterId(dto.getWriterId());
         resultDto.setWriterNickname(dto.getWriterNickname());
         resultDto.setMatePostId(dto.getMatePostId());


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
-  메이트찾기 목록 조회할때 프론트엔드로 전송하는 dto의 필드명 skillList를 skillLevelList로 수정함.

closed #185
