### PR TITLE
테스트 를 위한 일부 로직 주석 처리 및 상대팀 매칭 신청자의 CANCELED 조건 변경

### DIFF
--- a/src/main/java/sync/slamtalk/mate/entity/Participant.java
+++ b/src/main/java/sync/slamtalk/mate/entity/Participant.java
@@ -80,17 +80,18 @@ public class Participant extends BaseEntity {
         return true;
     }
 
+    // todo : 테스트 용이성을 위해 임시로 주석 처리
     public boolean checkCapabilities(List<PositionListDTO> requiredPosition, List<String> requiredSkillLevel) {
-        if(requiredSkillLevel.contains(this.skillLevel.getLevel()) == false){
-            return false;
-        }
-        for(PositionListDTO positionListDTO : requiredPosition){
-            if(positionListDTO.getPosition().equals(this.position.getPosition())){
-                if(positionListDTO.getMaxPosition() - positionListDTO.getCurrentPosition() <= 0){
-                    return false;
-                }
-            }
-        }
+//        if(requiredSkillLevel.contains(this.skillLevel.getLevel()) == false){
+//            return false;
+//        }
+//        for(PositionListDTO positionListDTO : requiredPosition){
+//            if(positionListDTO.getPosition().equals(this.position.getPosition())){
+//                if(positionListDTO.getMaxPosition() - positionListDTO.getCurrentPosition() <= 0){
+//                    return false;
+//                }
+//            }
+//        }
         return true;
     }
 

--- a/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamApplicant.java
@@ -51,7 +51,13 @@ public class TeamApplicant extends BaseEntity {
         this.teamMatching = null;
     }
 
-
+    @Override
+    public void delete() {
+        if(this.applyStatus != ApplyStatusType.CANCELED){
+            throw new BaseException(TEAM_POST_NOT_FOUND);
+        }
+        super.delete();
+    }
 
 
     public boolean checkCapabilities(List<String> requiredSkillLevel) {

--- a/src/main/java/sync/slamtalk/team/error/TeamErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/team/error/TeamErrorResponseCode.java
@@ -15,7 +15,8 @@ public enum TeamErrorResponseCode implements ResponseCodeDetails {
     ALEADY_DECLARED_OPPONENT(SC_BAD_REQUEST, 4010, "이미 상대팀을 선언한 글입니다."),
     OVER_LIMITED_NUMBERS(SC_BAD_REQUEST, 4011, "모집 인원을 초과하여 지원할 수 없습니다."),
     APPLICANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 지원자를 찾을 수 없습니다."),
-    OPPONENT_NOT_DECLARED(SC_BAD_REQUEST, 4012, "상대팀이 선언되지 않은 글입니다.");
+    OPPONENT_NOT_DECLARED(SC_BAD_REQUEST, 4012, "상대팀이 선언되지 않은 글입니다."),
+    NOT_ALLOWED_REQUEST(SC_BAD_REQUEST, 4013, "요청이 허용되지 않습니다.");
 
     TeamErrorResponseCode(int code, int status, String message) {
         this.code = code;


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
### 1. 상대팀 매칭 로직 수정 ###
- 취소했던 신청자가 다시 신청할 때 WAITING 상태로 복구하도록 로직 수정(WAITING 외 다른 신청 상태에선 CANCELED 상태로 변경 못함)
- 모집 완료 api 요청 시 성공적이면 해당 모집 글 COMPLETED 상태로 변경
### 2. 메이트찾기 로직 수정 ###
- 신청자를 수락할 때 신청자의 적합성 여부 검사 임시 중단(주석 처리)


closed #189