### PR TITLE
#80 feat : 마이페이지 팀매칭 개수, 상대팀 매칭 개수 구하는 로직 추가 

### DIFF
--- a/src/main/java/sync/slamtalk/mate/repository/MatePostRepository.java
+++ b/src/main/java/sync/slamtalk/mate/repository/MatePostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import sync.slamtalk.mate.entity.MatePost;
+import sync.slamtalk.user.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,5 +24,8 @@ public interface MatePostRepository extends JpaRepository<MatePost, Long> {
             "where p.participantId = :userId " +
             "and m.recruitmentStatus = 'COMPLETED' " +
             "and p.applyStatus = 'ACCEPTED'")
-    Long findMateCompleteParticipationCount(@Param("userId") Long userId);
+    long findMateCompleteParticipationCount(@Param("userId") Long userId);
+
+    @Query("select count(*) from MatePost m where m.writer = :writer and m.recruitmentStatus = 'COMPLETED'")
+    long countMatePostByWriter(@Param("writer") User writer);
 }

--- a/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.entity.TeamMatching;
+import sync.slamtalk.user.entity.User;
 
 import java.awt.print.Pageable;
 import java.time.LocalDateTime;
@@ -21,4 +22,16 @@ public interface TeamMatchingRepository extends JpaRepository<TeamMatching, Long
     @EntityGraph(value = "TeamMatching.forEagerApplicants")
     @Query("select t from TeamMatching t where t.createdAt < :cursor and t.isDeleted != true order by t.createdAt desc")
     List<TeamMatching> findAllByCreatedAtBefore(@Param("cursor")LocalDateTime cursor, PageRequest request);
+
+    /* 레벨 시스템 : 모집상태가 완료된 사용자의 개수를 반환하는 메서드 */
+    @Query("select count(*) " +
+            "from TeamMatching t " +
+            "join TeamApplicant a on t.teamMatchingId = a.teamMatching.teamMatchingId " +
+            "where a.applicantId = :userId " +
+            "and t.recruitmentStatus = 'COMPLETED' " +
+            "and a.applyStatus = 'ACCEPTED'")
+    long findTeamMatchingByCompleteParticipationCount(@Param("userId") Long userId);
+
+    @Query("select count(*) from TeamMatching t where t.writer = :writer and t.recruitmentStatus = 'COMPLETED'")
+    long countTeamMatchingByWriter(@Param("writer") User writer);
 }

--- a/src/main/java/sync/slamtalk/user/dto/response/UserDetailsMyInfo.java
+++ b/src/main/java/sync/slamtalk/user/dto/response/UserDetailsMyInfo.java
@@ -42,7 +42,8 @@ public class UserDetailsMyInfo {
     public static UserDetailsMyInfo generateMyProfile(
             User user,
             long levelScore,
-            long mateCompleteParticipationCount
+            long mateCompleteParticipationCount,
+            long teamCompleteParticipationCount
     ){ return UserDetailsMyInfo.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
@@ -53,7 +54,7 @@ public class UserDetailsMyInfo {
                 .level(levelScore/User.LEVEL_THRESHOLD)
                 .levelScore(levelScore)
                 .mateCompleteParticipationCount(mateCompleteParticipationCount)
-                .teamMatchingCompleteParticipationCount(0L)
+                .teamMatchingCompleteParticipationCount(teamCompleteParticipationCount)
                 .email(user.getEmail())
                 .socialType(user.getSocialType())
                 .role(user.getRole())

--- a/src/main/java/sync/slamtalk/user/dto/response/UserDetailsOtherInfo.java
+++ b/src/main/java/sync/slamtalk/user/dto/response/UserDetailsOtherInfo.java
@@ -28,13 +28,15 @@ public class UserDetailsOtherInfo {
      * 상대방 프로필 조회 시 필요한 정보를 반환하는 생성자
      *
      * @param user db에서 조회한 user 객체
-     * @param mateCompleteParticipationCount
+     * @param mateCount 메이트 총 개수
+     * @param teamCount 팀 총 개수
      * @return UserDetailsInfoResponseDto 개인정보 제외된 정보
      */
     public static UserDetailsOtherInfo generateOtherUserProfile(
             User user,
             long levelScore,
-            long mateCompleteParticipationCount
+            long mateCount,
+            long teamCount
     ) { return UserDetailsOtherInfo.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
@@ -44,8 +46,8 @@ public class UserDetailsOtherInfo {
                 .basketballPosition(user.getBasketballPosition() == null ?null:user.getBasketballPosition().getPosition())
                 .levelScore(levelScore)
                 .level(levelScore / User.LEVEL_THRESHOLD)
-                .mateCompleteParticipationCount(mateCompleteParticipationCount)
-                .teamMatchingCompleteParticipationCount(0L)
+                .mateCompleteParticipationCount(mateCount)
+                .teamMatchingCompleteParticipationCount(teamCount)
                 .build();
 
     }


### PR DESCRIPTION
## 📝 작업 내용

- getMateCount : 유저가 Mate 매칭 상태가 Completed에 참여한 개수를 구하는 메서드
- getTeamCount : 유저가 Team 매칭 상태가 Completed에 참여한 개수를 구하는 메서드
- MatePostRepository
  - 매칭상태가 COMPLETE이고 게시자가 userId인 것의 개수를  구하는 메서드 추가
  - 매칭상태가 COMPLETE이고 참여자 상태가 accepted 상태인 참여자 개수를 구하는 메서드 추가
- TeamMatchingRepository 에 쿼리를 추가했습니다
-   - 매칭상태가 COMPLETE이고 게시자가 userId인 것의 개수를  구하는 메서드 추가
  - 매칭상태가 COMPLETE이고 참여자 상태가 accepted 상태인 참여자 개수를 구하는 메서드 추가

## 💬 리뷰 요구사항
- Mate와 TeamMatching 부분 Repository를 수정하였습니다!

resolved : #80