### PR TITLE
#195 리프레시 토큰 업데이트 하는 로직 및 NPE 뜨던 오류 해결

### DIFF
--- a/src/main/java/sync/slamtalk/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/sync/slamtalk/security/jwt/JwtTokenProvider.java
@@ -229,16 +229,16 @@ public class JwtTokenProvider implements InitializingBean {
         User user = userRepository.findByRefreshToken(refreshToken)
                 .orElse(null);
 
-        // 권한 정보 가져오기
-        String authorities = user.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
-
-        log.debug("authorities = {}", authorities);
-
-        String accessToken = createAccessToken(user, authorities);
-
         if(user != null) {
+            // 권한 정보 가져오기
+            String authorities = user.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.joining(","));
+
+            log.debug("authorities = {}", authorities);
+
+            String accessToken = createAccessToken(user, authorities);
+
             return Optional.of(new JwtTokenDto(GRANT_TYPE, accessToken, refreshToken));
         }
         return Optional.empty();

--- a/src/main/java/sync/slamtalk/user/service/AuthService.java
+++ b/src/main/java/sync/slamtalk/user/service/AuthService.java
@@ -77,6 +77,7 @@ public class AuthService {
 
             response.addHeader(accessAuthorizationHeader, jwtTokenDto.getAccessToken());
             setRefreshTokenCookie(response, jwtTokenDto.getRefreshToken());
+            user.updateRefreshToken(jwtTokenDto.getRefreshToken());
 
             // 최초 정보수집을 위해 jwtTokenResponseDto의 firstLoginCheck은 true 로 반환, 이후는 false 로 반환하기 위한 로직
             if(Boolean.TRUE.equals(user.getFirstLoginCheck())) user.updateFirstLoginCheck();
@@ -169,7 +170,7 @@ public class AuthService {
             throw new BaseException(UserErrorResponseCode.INVALID_TOKEN);
         }
 
-        // 엑세스 토큰 만료가 되었다면 RTR 방식으로 재발급 하기
+        // 엑세스 토큰 만료가 되었다면 재발급 하기
         Optional<JwtTokenDto> optionalJwtTokenResponseDto = tokenProvider.generateNewAccessToken(refreshToken);
 
         if (optionalJwtTokenResponseDto.isEmpty()) {
@@ -178,7 +179,7 @@ public class AuthService {
 
         JwtTokenDto jwtTokenDto = optionalJwtTokenResponseDto.get();
 
-        /* 엑세스 토큰 헤더에 저장 및 리프레쉬 토큰 쿠키에 저장하는 로직 */
+        /* 엑세스 토큰 헤더에 저장*/
         response.addHeader(accessAuthorizationHeader, jwtTokenDto.getAccessToken());
     }
 


### PR DESCRIPTION
## 📝 작업 내용
[AuthService - login 메서드] 
- refactor : 리프레시 토큰 업데이트 하는 로직 추가
  - 기존에 refreshToken이 업데이트가 되지않는 현상이 있어서 수정하였습니다
  
[JwtTokenProvider - generateNewAccessToken 메서드]
- refactor : NPE 발생을 잡기 위한 리팩터링
  - user != null 이 아닐 경우만 권한 정보 가져가져와서 토큰을 반환하고 아닐 경우는 Option.empty를 반환하게끔 리팩터링

resolved : #195 
