### PR TITLE
#197 fit : admin 권한 설정 수정

### DIFF
--- a/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
+++ b/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig {
                                     "/api/match/read/**",
                                     "/api/match/list"
                                     ).permitAll();
-                            request.requestMatchers("/api/admin/**").hasRole(UserRole.ADMIN.getKey());
+                            request.requestMatchers("/api/admin/**").hasAnyAuthority(UserRole.ADMIN.getKey());
                             request.anyRequest().authenticated();
                         }
                 )


### PR DESCRIPTION
## 📝 작업 내용

원인 : 에러 메시지에 따르면, SecurityConfig 클래스의 filterChain 메서드에서 발생한 문제로 보입니다. 구체적으로는 ROLE_ADMIN이 ROLE_로 시작하는데, 이는 hasAnyRole을 사용할 때 ROLE_이 자동으로 붙기 때문에 문제가 발생

해결 : 이 문제를 해결하기 위해서  hasAnyAuthority는 ROLE_을 자동으로 추가하지 않으므로 이러한 충돌을 방지할 수 있습니다.

resolved : #197