### PR TITLE
#194 MYP15, MYP16 내가 참석한 팀 매칭 내역, 농구 메이트 내역, 임박한 매칭 전달하기!

### DIFF
--- a/src/main/java/sync/slamtalk/mate/controller/MatePostController.java
+++ b/src/main/java/sync/slamtalk/mate/controller/MatePostController.java
@@ -10,19 +10,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.mate.dto.MateFormDTO;
-import sync.slamtalk.mate.dto.MatePostDTO;
 import sync.slamtalk.mate.dto.MatePostListDTO;
 import sync.slamtalk.mate.dto.MateSearchCondition;
-import sync.slamtalk.mate.entity.MatePost;
-import sync.slamtalk.mate.entity.PositionType;
-import sync.slamtalk.mate.entity.SkillLevelType;
+import sync.slamtalk.mate.dto.response.MyMateListRes;
 import sync.slamtalk.mate.service.MatePostService;
 
 import java.net.URI;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -115,5 +108,16 @@ public class MatePostController {
     public ApiResponse completeRecruitment(@PathVariable("matePostId") long matePostId, @AuthenticationPrincipal Long id){
         matePostService.completeRecruitment(matePostId, id);
         return ApiResponse.ok();
+    }
+
+    @Operation(
+            summary = "내가 쓴/신청한 메이트 목록 ",
+            description = "나의 메이트 매칭 관련 모든 과거기록 및 신청한 리스트를 전송합니다.",
+            tags = {"메이트 찾기"}
+    )
+    @GetMapping("/my-list")
+    public ApiResponse<MyMateListRes> getMyMateList(@AuthenticationPrincipal Long userId){
+        MyMateListRes myMateListRes = matePostService.getMyMateList(userId);
+        return ApiResponse.ok(myMateListRes);
     }
 }

--- a/src/main/java/sync/slamtalk/mate/dto/response/MyMateListRes.java
+++ b/src/main/java/sync/slamtalk/mate/dto/response/MyMateListRes.java
@@ -1,0 +1,15 @@
+package sync.slamtalk.mate.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sync.slamtalk.mate.dto.MatePostToDto;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class MyMateListRes {
+
+    List<MatePostToDto> authoredPost; // 내가 쓴 글
+    List<MatePostToDto> participatedPost; // 내가 참여한 글
+}

--- a/src/main/java/sync/slamtalk/mate/mapper/EntityToDtoMapper.java
+++ b/src/main/java/sync/slamtalk/mate/mapper/EntityToDtoMapper.java
@@ -1,12 +1,8 @@
 package sync.slamtalk.mate.mapper;
 
-import com.querydsl.core.Tuple;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
-import sync.slamtalk.mate.dto.MatePostDTO;
-import sync.slamtalk.mate.dto.MatePostToDto;
-import sync.slamtalk.mate.dto.PositionListDTO;
-import sync.slamtalk.mate.dto.UnrefinedMatePostDTO;
+import sync.slamtalk.mate.dto.*;
 import sync.slamtalk.mate.entity.*;
 
 import java.util.ArrayList;
@@ -182,6 +178,50 @@ public class EntityToDtoMapper {
         resultDto.setLocationDetail(dto.getLocation() + " " + dto.getLocationDetail());
         resultDto.setPositionList(positionList);
         resultDto.setCreatedAt(dto.getCreatedAt());
+
+        return resultDto;
+    }
+
+    /**
+     * MatePost 에서 MatePostToDto로 변환하는 Mapper 매서드
+     * @param matePost : entity
+     * @return MatePostToDto : response dto
+     * */
+    public MatePostToDto FromMatePostToMatePostDto(MatePost matePost){
+        List<PositionListDTO> positionList = new ArrayList<>();
+
+        if(matePost.getMaxParticipantsCenters() > 0){
+            PositionListDTO positionListDTO = new PositionListDTO(PositionType.CENTER.getPosition(), matePost.getMaxParticipantsCenters(), matePost.getCurrentParticipantsCenters());
+            positionList.add(positionListDTO);
+        }else
+        if(matePost.getMaxParticipantsForwards() > 0){
+            PositionListDTO positionListDTO = new PositionListDTO(PositionType.FORWARD.getPosition(), matePost.getMaxParticipantsForwards(), matePost.getCurrentParticipantsForwards());
+            positionList.add(positionListDTO);
+        }
+        if(matePost.getMaxParticipantsGuards() > 0){
+            PositionListDTO positionListDTO = new PositionListDTO(PositionType.GUARD.getPosition(), matePost.getMaxParticipantsGuards(), matePost.getCurrentParticipantsGuards());
+            positionList.add(positionListDTO);
+        }
+        if(matePost.getMaxParticipantsOthers() > 0){
+            PositionListDTO positionListDTO = new PositionListDTO(PositionType.UNSPECIFIED.getPosition(), matePost.getMaxParticipantsOthers(), matePost.getCurrentParticipantsOthers());
+            positionList.add(positionListDTO);
+        }
+
+        MatePostToDto resultDto = new MatePostToDto();
+        resultDto.setSkillLevelList(toSkillLevelTypeList(matePost.getSkillLevel()));
+        resultDto.setWriterId(matePost.getWriterId());
+        resultDto.setWriterNickname(matePost.getWriterNickname());
+        resultDto.setMatePostId(matePost.getMatePostId());
+        resultDto.setScheduledDate(matePost.getScheduledDate());
+        resultDto.setStartTime(matePost.getStartTime());
+        resultDto.setEndTime(matePost.getEndTime());
+        resultDto.setTitle(matePost.getTitle());
+        resultDto.setContent(matePost.getContent());
+        resultDto.setSkillLevel(matePost.getSkillLevel());
+        resultDto.setRecruitmentStatus(matePost.getRecruitmentStatus());
+        resultDto.setLocationDetail(matePost.getLocation() + " " + matePost.getLocationDetail());
+        resultDto.setPositionList(positionList);
+        resultDto.setCreatedAt(matePost.getCreatedAt());
 
         return resultDto;
     }

--- a/src/main/java/sync/slamtalk/mate/mapper/EntityToDtoMapper.java
+++ b/src/main/java/sync/slamtalk/mate/mapper/EntityToDtoMapper.java
@@ -193,7 +193,7 @@ public class EntityToDtoMapper {
         if(matePost.getMaxParticipantsCenters() > 0){
             PositionListDTO positionListDTO = new PositionListDTO(PositionType.CENTER.getPosition(), matePost.getMaxParticipantsCenters(), matePost.getCurrentParticipantsCenters());
             positionList.add(positionListDTO);
-        }else
+        }
         if(matePost.getMaxParticipantsForwards() > 0){
             PositionListDTO positionListDTO = new PositionListDTO(PositionType.FORWARD.getPosition(), matePost.getMaxParticipantsForwards(), matePost.getCurrentParticipantsForwards());
             positionList.add(positionListDTO);

--- a/src/main/java/sync/slamtalk/mate/repository/MatePostRepository.java
+++ b/src/main/java/sync/slamtalk/mate/repository/MatePostRepository.java
@@ -2,6 +2,7 @@ package sync.slamtalk.mate.repository;
 
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -28,4 +29,16 @@ public interface MatePostRepository extends JpaRepository<MatePost, Long> {
 
     @Query("select count(*) from MatePost m where m.writer = :writer and m.recruitmentStatus = 'COMPLETED'")
     long countMatePostByWriter(@Param("writer") User writer);
+
+    /* 내가 쓴 글 조회*/
+    @EntityGraph(attributePaths = {"participants", "writer"})
+    List<MatePost> findAllByWriter(@Param("writer") User writer);
+
+    /* 내가 참여한 글 조회*/
+    @Query("select distinct m " +
+            "from MatePost m " +
+            "join fetch m.participants p " +
+            "where p.participantId =:participantId")
+    List<MatePost> findAllByApplicationId(@Param("participantId") Long participantId);
+
 }

--- a/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
+++ b/src/main/java/sync/slamtalk/team/controller/TeamMatchingController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import sync.slamtalk.common.ApiResponse;
 import sync.slamtalk.mate.entity.ApplyStatusType;
 import sync.slamtalk.team.dto.*;
+import sync.slamtalk.team.dto.response.MyTeamMatchingListRes;
 import sync.slamtalk.team.service.TeamMatchingService;
 
 import java.net.URI;
@@ -168,6 +169,14 @@ public class TeamMatchingController {
         return ApiResponse.ok();
     }
 
-
-
+    @Operation(
+            summary = "내가 쓴/신청한 팀 매칭 목록 보기",
+            description = "나의 팀매칭 관련 모든 과거기록 및 신청한 리스트를 전송합니다.",
+            tags = {"팀 매칭 / 신청자 목록"}
+    )
+    @GetMapping("/my-list")
+    public ApiResponse<MyTeamMatchingListRes> getMyTeamMatchingList(@AuthenticationPrincipal Long userId){
+        MyTeamMatchingListRes myTeamMatchingListRes = teamMatchingService.getMyTeamMatchingList(userId);
+        return ApiResponse.ok(myTeamMatchingListRes);
+    }
 }

--- a/src/main/java/sync/slamtalk/team/dto/response/MyTeamMatchingListRes.java
+++ b/src/main/java/sync/slamtalk/team/dto/response/MyTeamMatchingListRes.java
@@ -1,0 +1,17 @@
+package sync.slamtalk.team.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sync.slamtalk.team.dto.ToTeamFormDTO;
+
+import java.util.List;
+
+/**
+ * 나의 팀매칭 리스트 상세보기 reponse dto
+ * */
+@Getter
+@AllArgsConstructor
+public class MyTeamMatchingListRes {
+    List<ToTeamFormDTO> authoredPost; // 내가 쓴 글
+    List<ToTeamFormDTO> participatedPost; // 내가 참여한 글
+}

--- a/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
+++ b/src/main/java/sync/slamtalk/team/repository/TeamMatchingRepository.java
@@ -1,17 +1,14 @@
 package sync.slamtalk.team.repository;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import sync.slamtalk.mate.entity.RecruitmentStatusType;
 import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.user.entity.User;
 
-import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -34,4 +31,15 @@ public interface TeamMatchingRepository extends JpaRepository<TeamMatching, Long
 
     @Query("select count(*) from TeamMatching t where t.writer = :writer and t.recruitmentStatus = 'COMPLETED'")
     long countTeamMatchingByWriter(@Param("writer") User writer);
+
+    /* 내가 작성한 팀매칭 리스트를 조회*/
+    @EntityGraph(attributePaths = {"teamApplicants", "writer"})
+    List<TeamMatching> findAllByWriter(@Param("writer") User writer);
+
+    /* 내가 지원한 팀매칭 리스트를 조회*/
+    @Query("select distinct t " +
+            "from TeamMatching t " +
+            "join fetch t.teamApplicants a " +
+            "where a.applicantId =:applicantId")
+    List<TeamMatching> findAllByApplicationId(@Param("applicantId") Long applicantId);
 }

--- a/src/main/java/sync/slamtalk/user/controller/UserController.java
+++ b/src/main/java/sync/slamtalk/user/controller/UserController.java
@@ -13,6 +13,7 @@ import sync.slamtalk.user.dto.request.UserUpdateNicknameReq;
 import sync.slamtalk.user.dto.request.UserUpdatePositionAndSkillReq;
 import sync.slamtalk.user.dto.response.UserDetailsMyInfo;
 import sync.slamtalk.user.dto.response.UserDetailsOtherInfo;
+import sync.slamtalk.user.dto.response.UserSchedule;
 import sync.slamtalk.user.service.UserService;
 
 /**
@@ -147,6 +148,23 @@ public class UserController {
     ) {
         userService.updateUserDetailInfo(userId, file, updateUserDetailInfoReq);
         return ApiResponse.ok();
+    }
+
+    /**
+     * 현재날짜 이후의 모든 약속 리스트를 반환하는 api
+     * @param userId 유저 아이디
+     * */
+    @GetMapping("/user/scheduleList")
+    @Operation(
+            summary = "임박한 약속 리스트 api",
+            description = "현재날짜 이후의 상태가 COMPLETED 약속 리스트를 팀매칭, 상대팀매칭 별로 구분해서 전달합니다.",
+            tags = {"유저 상세정보 조회"}
+    )
+    public ApiResponse<UserSchedule> userMyScheduleList(
+            @AuthenticationPrincipal Long userId
+    ) {
+        UserSchedule userMyScheduleList = userService.userMyScheduleList(userId);
+        return ApiResponse.ok(userMyScheduleList);
     }
 
 }

--- a/src/main/java/sync/slamtalk/user/dto/response/UserSchedule.java
+++ b/src/main/java/sync/slamtalk/user/dto/response/UserSchedule.java
@@ -1,0 +1,18 @@
+package sync.slamtalk.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sync.slamtalk.mate.dto.MatePostToDto;
+import sync.slamtalk.team.dto.ToTeamFormDTO;
+
+import java.util.List;
+
+/**
+ * 임박한 유저 스케줄 반환하는 response dto
+ * */
+@AllArgsConstructor
+@Getter
+public class UserSchedule {
+    List<ToTeamFormDTO> teamMatchingList;
+    List<MatePostToDto> mateList;
+}

--- a/src/main/java/sync/slamtalk/user/service/UserService.java
+++ b/src/main/java/sync/slamtalk/user/service/UserService.java
@@ -7,7 +7,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import sync.slamtalk.common.BaseException;
 import sync.slamtalk.common.s3bucket.repository.AwsS3RepositoryImpl;
+import sync.slamtalk.mate.dto.MatePostToDto;
+import sync.slamtalk.mate.entity.ApplyStatusType;
+import sync.slamtalk.mate.entity.MatePost;
+import sync.slamtalk.mate.entity.RecruitmentStatusType;
+import sync.slamtalk.mate.mapper.EntityToDtoMapper;
 import sync.slamtalk.mate.repository.MatePostRepository;
+import sync.slamtalk.team.dto.ToTeamFormDTO;
+import sync.slamtalk.team.entity.TeamMatching;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
 import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.dto.request.UpdateUserDetailInfoReq;
@@ -15,16 +22,20 @@ import sync.slamtalk.user.dto.request.UserUpdateNicknameReq;
 import sync.slamtalk.user.dto.request.UserUpdatePositionAndSkillReq;
 import sync.slamtalk.user.dto.response.UserDetailsMyInfo;
 import sync.slamtalk.user.dto.response.UserDetailsOtherInfo;
+import sync.slamtalk.user.dto.response.UserSchedule;
 import sync.slamtalk.user.entity.User;
 import sync.slamtalk.user.entity.UserAttendance;
 import sync.slamtalk.user.error.UserErrorResponseCode;
 import sync.slamtalk.user.repository.UserAttendanceRepository;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 이 서비스는 유저의 crud 와 관련된 클래스입니다.
- * */
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -35,12 +46,13 @@ public class UserService {
     private final TeamMatchingRepository teamMatchingRepository;
     private final MatePostRepository matePostRepository;
     private final AwsS3RepositoryImpl awsS3Service;
+    private final EntityToDtoMapper entityToDtoMapper;
 
     /**
      * 유저의 마이페이지 보기 조회시 사용되는 서비스
-     * @param userId 찾고자하는 userId
      *
-     * */
+     * @param userId 찾고자하는 userId
+     */
     public UserDetailsMyInfo userDetailsMyInfo(
             Long userId
     ) {
@@ -100,21 +112,21 @@ public class UserService {
         levelScore += userAttendCount * User.ATTEND_SCORE;
 
         // 찾고자 하는 유저가 본인이 아닐경우(개인정보 제외하고 공개)
-         return UserDetailsOtherInfo.generateOtherUserProfile(
+        return UserDetailsOtherInfo.generateOtherUserProfile(
                 user,
                 levelScore,
                 mateCount,
-                 teamCount
+                teamCount
         );
     }
 
     /**
      * 팀매칭 완료된 곳에 참여한 개수 구하는 메서드
-     * @param userId : 유저 아이디
-     * @param user : 유저 객체
      *
+     * @param userId : 유저 아이디
+     * @param user   : 유저 객체
      * @return count : 개수
-     * */
+     */
     private long getTeamCount(Long userId, User user) {
         long count = 0L;
         count += teamMatchingRepository.countTeamMatchingByWriter(user);
@@ -124,11 +136,11 @@ public class UserService {
 
     /**
      * Mate매칭 완료된 곳에 참여한 개수 구하는 메서드
-     * @param userId : 유저 아이디
-     * @param user : 유저 객체
      *
+     * @param userId : 유저 아이디
+     * @param user   : 유저 객체
      * @return count : 개수
-     * */
+     */
     private long getMateCount(Long userId, User user) {
         long count = 0L;
         count += matePostRepository.findMateCompleteParticipationCount(userId);
@@ -139,15 +151,15 @@ public class UserService {
     /**
      * 유저 닉네임 변경 로직
      *
-     * @param userId 유저아이디,
+     * @param userId                유저아이디,
      * @param userUpdateNicknameReq 유저 닉네임 변경 request dto
-     * */
+     */
     @Transactional
     public void userUpdateNickname(
             Long userId,
             UserUpdateNicknameReq userUpdateNicknameReq
     ) {
-        log.debug("유저 아이디 "+ userId);
+        log.debug("유저 아이디 " + userId);
         checkNicknameExistence(userUpdateNicknameReq.getNickname());
         userRepository.updateUserNickname(userId, userUpdateNicknameReq.getNickname());
     }
@@ -155,8 +167,8 @@ public class UserService {
     /**
      * 회원가입 시 중복 닉네임이 존재하는지 검사하는 메서드
      *
-     * @param  nickname 유저 닉네임
-     * */
+     * @param nickname 유저 닉네임
+     */
 
     private void checkNicknameExistence(String nickname) {
         String lowercaseNickname = nickname.toLowerCase();
@@ -167,11 +179,11 @@ public class UserService {
     }
 
     /**
-     *  유저의 스킬 레벨 타입과, 농구 포지션을 업데이트하는 서비스
+     * 유저의 스킬 레벨 타입과, 농구 포지션을 업데이트하는 서비스
      *
-     * @param userId 유저 아이디
+     * @param userId                        유저 아이디
      * @param userUpdatePositionAndSkillReq 유저 레벨타입과, 농구포지션으로 요청이온 dto
-     * */
+     */
     @Transactional
     public void userUpdatePositionAndSkillLevel(
             Long userId,
@@ -188,14 +200,14 @@ public class UserService {
      * 유저 출석체크를 위한 api
      *
      * @param userId 유저 아이디
-     * */
+     */
     @Transactional
     public void userAttendance(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
 
         // 만약 이미 출석을 했다면 400 에러 반환
-        if(userAttendanceRepository.existsByUserAndAttDate(user, LocalDate.now())){
+        if (userAttendanceRepository.existsByUserAndAttDate(user, LocalDate.now())) {
             throw new BaseException(UserErrorResponseCode.ATTENDANCE_ALREADY_EXISTS);
         }
 
@@ -205,10 +217,11 @@ public class UserService {
 
     /**
      * 유저 마이페이지 수정 api
-     * @param userId 유저아이디
-     * @param file MultipartFile 업로드
+     *
+     * @param userId                  유저아이디
+     * @param file                    MultipartFile 업로드
      * @param updateUserDetailInfoReq UpdateUserDetailInfoRequestDto
-     * */
+     */
     @Transactional
     public void updateUserDetailInfo(
             Long userId,
@@ -218,30 +231,139 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
         // 닉네임 검증
-        if(updateUserDetailInfoReq.getNickname() != null) {
+        if (updateUserDetailInfoReq.getNickname() != null) {
             checkNicknameExistence(updateUserDetailInfoReq.getNickname());
             user.updateNickname(updateUserDetailInfoReq.getNickname());
         }
 
         // 이미지 파일이 존재한다면 업데이트
-        if(file != null) {
+        if (file != null) {
             String fileUrl = awsS3Service.uploadFile(file);
             user.updateProfileUrl(fileUrl);
         }
 
         // 자기 소개 한마디
-        if(updateUserDetailInfoReq.getSelfIntroduction() != null){
+        if (updateUserDetailInfoReq.getSelfIntroduction() != null) {
             user.updateSelfIntroduction(updateUserDetailInfoReq.getSelfIntroduction());
         }
 
         // 유저 포지션
-        if(updateUserDetailInfoReq.getBasketballPosition() != null){
+        if (updateUserDetailInfoReq.getBasketballPosition() != null) {
             user.updatePosition(updateUserDetailInfoReq.getBasketballPosition());
         }
 
         // 유저 스킬 레벨 업데이트
-        if(updateUserDetailInfoReq.getBasketballSkillLevel() != null){
+        if (updateUserDetailInfoReq.getBasketballSkillLevel() != null) {
             user.updateBasketballSkillLevel(updateUserDetailInfoReq.getBasketballSkillLevel());
         }
+    }
+
+    /**
+     * 현재날짜 이후의 모든 스케줄 반환하는 메서드
+     * @param userId : 유저 아이디
+     * @return UserSchedule : 유저 스케줄
+     * */
+    public UserSchedule userMyScheduleList(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
+
+        List<ToTeamFormDTO> myTeamMatchingScheduleList = getMyTeamMatchingScheduleList(user);
+        List<MatePostToDto> mateList = getMyMateScheduleList(user);
+        return new UserSchedule(myTeamMatchingScheduleList, mateList);
+    }
+
+    /**
+     * 팀매칭 관련해서 내가 쓴 글/ 내가 참여한 글 중
+     * 상태가 COMPLETED 이고 현재날짜 이후의 데이터만 스케줄리스트로 전달하는 메서드
+     * @param user : 유저정보
+     * @return List<ToTeamFormDTO> : 팀 스케줄 리스트
+     * */
+    private List<ToTeamFormDTO> getMyTeamMatchingScheduleList(User user) {
+        List<TeamMatching> allByWriter = teamMatchingRepository.findAllByWriter(user);
+        List<TeamMatching> allByApplications = teamMatchingRepository.findAllByApplicationId(user.getId());
+
+        List<ToTeamFormDTO> authoredPost = allByWriter.stream()
+                .filter(teamMatching ->
+                        teamMatching.getRecruitmentStatus().equals(RecruitmentStatusType.COMPLETED) &&
+                                teamMatching.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (teamMatching.getScheduledDate().isEqual(LocalDate.now()) && teamMatching.getStartTime().isAfter(LocalTime.now()))
+                )
+                .map(teamMatchingEntity -> teamMatchingEntity.toTeamFormDto(new ToTeamFormDTO()))
+                .toList();
+
+        List<ToTeamFormDTO> participatedPost = allByApplications.stream()
+                .filter(teamMatching ->
+                        teamMatching.getRecruitmentStatus().equals(RecruitmentStatusType.COMPLETED) &&
+                                teamMatching.getTeamApplicants().stream()
+                                        .filter(teamApplicant ->
+                                                teamApplicant.getApplicantId().equals(user.getId()) &&
+                                                        !teamApplicant.getApplyStatus().equals(ApplyStatusType.ACCEPTED))
+                                        .findFirst().isEmpty() && // 해당 조건을 만족하는 참가자가 없으면
+                                teamMatching.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (teamMatching.getScheduledDate().isEqual(LocalDate.now()) && teamMatching.getStartTime().isAfter(LocalTime.now()))
+                )
+                .map(teamMatchingEntity -> teamMatchingEntity.toTeamFormDto(new ToTeamFormDTO()))
+                .map(toTeamFormDTO -> {
+                    toTeamFormDTO.setTeamApplicants(
+                            toTeamFormDTO.getTeamApplicants().stream()
+                                    .filter(toApplicantDto ->
+                                            toApplicantDto.getApplicantId().equals(user.getId()))
+                                    .toList()
+                    );
+                    return toTeamFormDTO;
+                })
+                .toList();
+        List<ToTeamFormDTO> teamMatchingList = new ArrayList<>();
+        teamMatchingList.addAll(authoredPost);
+        teamMatchingList.addAll(participatedPost);
+        return teamMatchingList;
+    }
+
+    /**
+     * 메이트 매칭 관련해서 내가 쓴 글/ 내가 참여한 글 중
+     * 상태가 COMPLETED 이고 현재날짜 이후의 데이터만 스케줄리스트로 전달하는 메서드
+     * @param user : 유저정보
+     * @return List<MatePostToDto> : 메이트 스케줄 리스트
+     * */
+    private List<MatePostToDto> getMyMateScheduleList(User user) {
+        List<MatePost> allByWriter = matePostRepository.findAllByWriter(user);
+        List<MatePost> allByApplications = matePostRepository.findAllByApplicationId(user.getId());
+
+        List<MatePostToDto> authoredPost = allByWriter.stream()
+                .filter(matePost ->
+                        matePost.getRecruitmentStatus().equals(RecruitmentStatusType.COMPLETED) &&
+                                matePost.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (matePost.getScheduledDate().isEqual(LocalDate.now()) && matePost.getStartTime().isAfter(LocalTime.now()))
+                )
+                .map(matePost -> entityToDtoMapper.FromMatePostToMatePostDto(matePost))
+                .toList();
+
+        List<MatePostToDto> participatedPost = allByApplications.stream()
+                .filter(matePost ->
+                        matePost.getRecruitmentStatus().equals(RecruitmentStatusType.COMPLETED) &&
+                                matePost.getParticipants().stream()
+                                        .filter(participant ->
+                                                participant.getParticipantId().equals(user.getId()) &&
+                                                        !participant.getApplyStatus().equals(ApplyStatusType.ACCEPTED))
+                                        .findFirst().isEmpty() && // 해당 조건을 만족하는 참가자가 없으면
+                                matePost.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (matePost.getScheduledDate().isEqual(LocalDate.now()) && matePost.getStartTime().isAfter(LocalTime.now()))
+                )
+                .map(matePost -> entityToDtoMapper.FromMatePostToMatePostDto(matePost))
+                .map(matePostToDto -> {
+                    matePostToDto.setParticipants(
+                            matePostToDto.getParticipants().stream()
+                                    .filter(participant ->
+                                            participant.getParticipantId().equals(user.getId())
+                                    )
+                                    .toList()
+                    );
+                    return matePostToDto;
+                })
+                .toList();
+        List<MatePostToDto> mateList = new ArrayList<>();
+        mateList.addAll(authoredPost);
+        mateList.addAll(participatedPost);
+        return mateList;
     }
 }

--- a/src/main/java/sync/slamtalk/user/service/UserService.java
+++ b/src/main/java/sync/slamtalk/user/service/UserService.java
@@ -285,8 +285,8 @@ public class UserService {
         List<ToTeamFormDTO> authoredPost = allByWriter.stream()
                 .filter(teamMatching ->
                         teamMatching.getRecruitmentStatus().equals(RecruitmentStatusType.COMPLETED) &&
-                                teamMatching.getScheduledDate().isAfter(LocalDate.now()) ||
-                                (teamMatching.getScheduledDate().isEqual(LocalDate.now()) && teamMatching.getStartTime().isAfter(LocalTime.now()))
+                                (teamMatching.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (teamMatching.getScheduledDate().isEqual(LocalDate.now()) && teamMatching.getStartTime().isAfter(LocalTime.now())))
                 )
                 .map(teamMatchingEntity -> teamMatchingEntity.toTeamFormDto(new ToTeamFormDTO()))
                 .toList();
@@ -299,8 +299,8 @@ public class UserService {
                                                 teamApplicant.getApplicantId().equals(user.getId()) &&
                                                         !teamApplicant.getApplyStatus().equals(ApplyStatusType.ACCEPTED))
                                         .findFirst().isEmpty() && // 해당 조건을 만족하는 참가자가 없으면
-                                teamMatching.getScheduledDate().isAfter(LocalDate.now()) ||
-                                (teamMatching.getScheduledDate().isEqual(LocalDate.now()) && teamMatching.getStartTime().isAfter(LocalTime.now()))
+                                (teamMatching.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (teamMatching.getScheduledDate().isEqual(LocalDate.now()) && teamMatching.getStartTime().isAfter(LocalTime.now())))
                 )
                 .map(teamMatchingEntity -> teamMatchingEntity.toTeamFormDto(new ToTeamFormDTO()))
                 .map(toTeamFormDTO -> {
@@ -332,8 +332,8 @@ public class UserService {
         List<MatePostToDto> authoredPost = allByWriter.stream()
                 .filter(matePost ->
                         matePost.getRecruitmentStatus().equals(RecruitmentStatusType.COMPLETED) &&
-                                matePost.getScheduledDate().isAfter(LocalDate.now()) ||
-                                (matePost.getScheduledDate().isEqual(LocalDate.now()) && matePost.getStartTime().isAfter(LocalTime.now()))
+                                (matePost.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (matePost.getScheduledDate().isEqual(LocalDate.now()) && matePost.getStartTime().isAfter(LocalTime.now())))
                 )
                 .map(matePost -> entityToDtoMapper.FromMatePostToMatePostDto(matePost))
                 .toList();
@@ -346,8 +346,8 @@ public class UserService {
                                                 participant.getParticipantId().equals(user.getId()) &&
                                                         !participant.getApplyStatus().equals(ApplyStatusType.ACCEPTED))
                                         .findFirst().isEmpty() && // 해당 조건을 만족하는 참가자가 없으면
-                                matePost.getScheduledDate().isAfter(LocalDate.now()) ||
-                                (matePost.getScheduledDate().isEqual(LocalDate.now()) && matePost.getStartTime().isAfter(LocalTime.now()))
+                                (matePost.getScheduledDate().isAfter(LocalDate.now()) ||
+                                (matePost.getScheduledDate().isEqual(LocalDate.now()) && matePost.getStartTime().isAfter(LocalTime.now())))
                 )
                 .map(matePost -> entityToDtoMapper.FromMatePostToMatePostDto(matePost))
                 .map(matePostToDto -> {


### PR DESCRIPTION
## 📝 작업 내용
[임박한 약속 리스트 api]
- /api/user/scheduleList
- 현재 날짜를 기준으로 이후로 내가 참여한 모든 임박한 약속 리스트를 전달
- 기능 설명 : 내가 쓴 메이트 찾기/ 내가 참여한 메이트의 상태가 COMPLETED이고 현재날짜 및 시간 이후의 글을 찾는 메서드
- 참여자일 경우 상태가 ACCEPTED 인 글만 반환한다.

[나의 메이트 찾기 리스트 조회 api]
- /api/mate/my-list
- 내가 참여한 모든 매칭 리스트를 전달
- 기능 설명 : 내가 쓴 메이트 찾기/ 내가 참여한 메이트 등 모든 메이트의 정보를 반환한다.

[나의 상태팀 매칭 리스트 조회 api]
- /api/match/my-list
- 내가 참여한 모든 매칭 리스트를 전달
- 기능 설명 : 내가 쓴 메이트 찾기/ 내가 참여한 메이트 등 모든 메이트의 정보를 반환한다.

resolved : #194 