### PR TITLE
과거 내역 가져오기 메세지 누락 문제 해결 시도

### DIFF
--- a/src/main/java/sync/slamtalk/chat/redis/RedisService.java
+++ b/src/main/java/sync/slamtalk/chat/redis/RedisService.java
@@ -72,7 +72,7 @@ public class RedisService {
         List<String> keyCollect = keys.stream()
                 .map(key -> key.split(":"))
                 // 분할된 배열에서 메시지 ID가 숫자 형태인지, 그리고 readIndex보다 작은지 확인
-                .filter(parts -> parts.length == 4 && parts[3].matches("\\d+") && Integer.parseInt(parts[3]) < readIndex)
+                .filter(parts -> parts.length == 4 && parts[3].matches("\\d+") && Integer.parseInt(parts[3]) <= readIndex)
                 // 원래 키 형태로 복원
                 .map(parts -> String.join(":", parts))
                 // 메시지 ID에 따라 내림차순 정렬

--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -319,6 +319,7 @@ public class ChatServiceImpl implements ChatService{
 
      */
     @Override
+    @Transactional
     public List<ChatMessageDTO> getPreviousChatMessages(Long userId, Long chatRoomId) {
 
         List<ChatMessageDTO> chatMessageDTOList = new ArrayList<>();


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 과거 내역 가져오는 메서드에 @Transactional 어노테이션추가
- 채팅방 과거 내역 요청 시 메세지 누락 문제 해결 시도(readIndex 까지 포함해서 과거내역 반환)
