### PR TITLE
bug : 채팅방 과거 내역 요청 시 메세지 누락 문제 해결 시도(메세지 저장하는 로직에도 @Transactional 추가)

### DIFF
--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -144,6 +144,7 @@ public class ChatServiceImpl implements ChatService{
 
     // 채팅방에 메세지 저장(STOMP: SEND)
     @Override
+    @Transactional
     public void saveMessage(ChatMessageDTO chatMessageDTO) {
         long chatRoomId = Long.parseLong(chatMessageDTO.getRoomId());
         Optional<ChatRoom> chatRoom = chatRoomRepository.findById(chatRoomId);


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 채팅방 과거 내역 요청 시 메세지 누락 문제 해결 시도(메세지 저장하는 로직에도 @Transactional 추가)
