### PR TITLE
bug : 채팅방 과거 내역 요청 시 메세지 누락 문제 해결 시도(메세지 db 저장 시 Redis 에도 저장하게 함)

### DIFF
--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -160,7 +160,7 @@ public class ChatServiceImpl implements ChatService{
                     .build();
             messagesRepository.save(messages);
 //            // redis 에도 저장..?
-//            redisService.saveMessage(chatMessageDTO,42300);
+            redisService.saveMessage(chatMessageDTO,42300);
         }else{
             throw new BaseException(ErrorResponseCode.CHAT_FAIL);
         }
@@ -391,9 +391,16 @@ public class ChatServiceImpl implements ChatService{
         // redis 에서 가져온 내역이 있는 경우
 
         // TODO 갯수 20개 못가져온경우 추가적으로 db 페이징
+        List<ChatMessageDTO> chatMessageDTOS = optionalList.get();
+        String messageId = chatMessageDTOS.get(chatMessageDTOS.size() - 1).getMessageId();
+        if(chatMessageDTOS.size()<needCnt){
+            int more = needCnt - chatMessageDTOS.size();
+            // 20 개 - redis 로 가져온 내역 갯수 = 추가 내역 페이징
+            Pageable pageable = PageRequest.of(0, more); // 첫 페이지, 최대 20개
+            List<Messages> messagesList = messagesRepository.findByChatRoomIdAndMessageIdLessThanOrderedByMessageIdDesc(chatRoomId, Long.parseLong(messageId), pageable);
+        }
 
         return optionalList.get();
-
     }
 
     // 특정 방에 저장된 메세지 중 가장 마지막 메세지 가져옴


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 채팅방 과거 내역 요청 시 메세지 누락 문제 해결 시도(메세지 db 저장 시 Redis 에도 저장하게 함)