### PR TITLE
bug : 채팅방 과거 내역 요청 시 메세지 누락 문제 해결 시도

### DIFF
--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -145,12 +145,15 @@ public class ChatServiceImpl implements ChatService{
 
     // 채팅방에 메세지 저장(STOMP: SEND)
     @Override
-    @Transactional
     public void saveMessage(ChatMessageDTO chatMessageDTO) {
         long chatRoomId = Long.parseLong(chatMessageDTO.getRoomId());
         Optional<ChatRoom> chatRoom = chatRoomRepository.findById(chatRoomId);
         if(chatRoom.isPresent()){ // chatRoom 이 존재하면
+            // redis 먼저 저장
+            redisService.saveMessage(chatMessageDTO,42300);
             ChatRoom Room = chatRoom.get();
+
+            // messages 저장
             // Message create
             Messages messages = Messages.builder()
                     .chatRoom(Room)
@@ -160,8 +163,6 @@ public class ChatServiceImpl implements ChatService{
                     .creation_time(chatMessageDTO.getTimestamp().toString())
                     .build();
             messagesRepository.save(messages);
-//            // redis 에도 저장..?
-            redisService.saveMessage(chatMessageDTO,42300);
         }else{
             throw new BaseException(ErrorResponseCode.CHAT_FAIL);
         }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 메세지저장시 redis에 먼저저장되도록함, `@Transactional`어노테이션 제거
