### PR TITLE
#226 refactor : 소셜 로그인 성공 및 실패 시 리다이렉트 url을 프론트 서버 url로 리팩터링

### DIFF
--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -20,7 +20,9 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
             AuthenticationException exception
     ) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
-        response.sendRedirect("http://localhost:3000?loginSuccess=false");
+//        response.sendRedirect("http://localhost:3000/social-login?loginSuccess=false");
+        response.sendRedirect("https://slam-talk.vercel.app/social-login?loginSuccess=false");
         log.debug("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+
     }
 }

--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -67,7 +67,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         setRefreshTokenCookie(response, refreshToken);
 
-        response.sendRedirect("http://localhost:3000/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
+//        response.sendRedirect("http://localhost:3000/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
+        response.sendRedirect("https://slam-talk.vercel.app/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
 
         // 최초 정보수집을 위해 jwtTokenResponseDto의 firstLoginCheck은 true 로 반환, 이후는 false 로 반환하기 위한 로직
         if(Boolean.TRUE.equals(user.getFirstLoginCheck())) user.updateFirstLoginCheck();


### PR DESCRIPTION
## 📝 작업 내용

- 소셜 로그인 성공 및 실패  리다이렉트 url을 프론트 서버로 변경

resolved : #226 
