### PR TITLE
#244 상대방 프로필 보기 게스트  권한 설정

### DIFF
--- a/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
+++ b/src/main/java/sync/slamtalk/security/config/SecurityConfig.java
@@ -91,7 +91,8 @@ public class SecurityConfig {
                                     "/api/match/read/**",
                                     "/api/match/list",
                                     "/api/community/category/**",
-                                    "/api/community/board/**"
+                                    "/api/community/board/**",
+                                    "/api/user/other-info/**"
                                     ).permitAll();
                             request.requestMatchers("/api/admin/**").hasAnyAuthority(UserRole.ADMIN.getKey());
                             request.anyRequest().authenticated();

--- a/src/main/java/sync/slamtalk/user/controller/UserController.java
+++ b/src/main/java/sync/slamtalk/user/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
      *
      * @return UserDetailsInfoResponseDto 객체가 반환(개인정보 있는 버전, 없는 버전)
      * */
-    @GetMapping("/user/{userId}/other-info")
+    @GetMapping("/user/other-info/{userId}")
     @Operation(
             summary = "다른 유저 상세 정보 조회 api",
             description = "다른 유저의 상세 정보를 조회할 때 유저 정보 반환 api 입니다",


### PR DESCRIPTION
## 📝 작업 내용
- 상대방 유저 프로필 보는 기존 /api/user/{userId}/other-info 를 다음과 같이 수정하려고 합니다.
- 게스트 권한 설정
- /api/user/other-info/{userId} GET Method
- 기존에 받는 값을 동일.

## 작업 상세 내용
- [x] url 수정
- [x] 게스트 권한 설정하기




## 💬 리뷰 요구사항
- yml 파일이 변경되었습니다
- 프론트 분들 url이 다음과 같이 수정되었습니다
-/api/user/{userId}/other-info => /api/user/other-info/{userId}

resolved : #244 
