### PR TITLE
#247 과거 내역 요청 에러 수정

### DIFF
--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -336,7 +336,7 @@ public class ChatServiceImpl implements ChatService{
     // 과거 메세지 추가 요청
     @Override
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
-    public List<ChatMessageDTO> getPreviousChatMessages(Long userId, Long chatRoomId,int count) {
+    public List<ChatMessageDTO>getPreviousChatMessages(Long userId, Long chatRoomId,int count) {
 
         List<ChatMessageDTO> chatMessageDTOList = new ArrayList<>();
 
@@ -364,6 +364,11 @@ public class ChatServiceImpl implements ChatService{
                 UserChatRoom userChatRoom = existUserChatRoom.get();
                 Long readIndex = userChatRoom.getReadIndex();
                 log.debug("=== readIndex : {}",readIndex);
+
+                // readIndex 가 초기값이면 바로 null return
+                if(readIndex.equals(0L)){
+                    return null;
+                }
 
                 // 20개씩 내역 페이징
                 Pageable pageable = PageRequest.of(0, 20); // 첫 페이지, 최대 20개


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 채팅 과거 내역 요청 에러 수정
    - readIndex가 0이면 (초기값에서 업데이트되지 않았으면) null 값 으로 반환하여 응답


closed #247 
