### PR TITLE
#250 유저 마이페이지 수정 로직 리팩터링 

### DIFF
--- a/src/main/java/sync/slamtalk/user/controller/UserController.java
+++ b/src/main/java/sync/slamtalk/user/controller/UserController.java
@@ -134,7 +134,7 @@ public class UserController {
      * @param file 파일 크기 1MB
      * @param updateUserDetailInfoReq 유저 프로필 업데이트 DTO
      * */
-    @PatchMapping("/user/update")
+    @PostMapping("/user/update")
     @Operation(
             summary = "마이페이지 수정 api",
             description = "마이페이지 수정할 때 닉네임, 프로필, 한마디, 포지션, 농구실력 을 수정 가능합니다. " +

--- a/src/main/java/sync/slamtalk/user/service/UserService.java
+++ b/src/main/java/sync/slamtalk/user/service/UserService.java
@@ -243,29 +243,29 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
         // 닉네임 검증
-        if (updateUserDetailInfoReq.getNickname() != null) {
+        if (!user.getNickname().equals(updateUserDetailInfoReq.getNickname()) && updateUserDetailInfoReq.getNickname() != null) {
             checkNicknameExistence(updateUserDetailInfoReq.getNickname());
             user.updateNickname(updateUserDetailInfoReq.getNickname());
         }
 
         // 이미지 파일이 존재한다면 업데이트
-        if (file != null) {
+        if (!file.isEmpty()) {
             String fileUrl = awsS3Service.uploadFile(file);
             user.updateProfileUrl(fileUrl);
         }
 
         // 자기 소개 한마디이 null이 아니라면 값 update 하기
-        if (updateUserDetailInfoReq.getSelfIntroduction() != null) {
+        if (!user.getSelfIntroduction().equals(updateUserDetailInfoReq.getSelfIntroduction()) && updateUserDetailInfoReq.getSelfIntroduction() != null) {
             user.updateSelfIntroduction(updateUserDetailInfoReq.getSelfIntroduction());
         }
 
         // 유저 포지션가 null이 아니라면 값 update 하기
-        if (updateUserDetailInfoReq.getBasketballPosition() != null) {
+        if (!user.getBasketballPosition().equals(updateUserDetailInfoReq.getBasketballPosition()) && updateUserDetailInfoReq.getBasketballPosition() != null) {
             user.updatePosition(updateUserDetailInfoReq.getBasketballPosition());
         }
 
         // 유저 스킬 레벨 업데이트가 null이 아니라면 update 하기
-        if (updateUserDetailInfoReq.getBasketballSkillLevel() != null) {
+        if (!user.getBasketballSkillLevel().equals(updateUserDetailInfoReq.getBasketballSkillLevel()) && updateUserDetailInfoReq.getBasketballSkillLevel() != null) {
             user.updateBasketballSkillLevel(updateUserDetailInfoReq.getBasketballSkillLevel());
         }
     }


### PR DESCRIPTION
## 📝 작업 내용

- /api/user/update 를 patch 에서 post 로 수정
  - 이유 :  multipart/form 데이터 형식은 주로 파일 업로드와 같은 전체 데이터를 보낼 때 사용됩니다. 이러한 두 가지는 의미적으로 맞지 않아서
- 파일이 이미지가 존재하지 않으면 이미지 업데이트 안하도록 설정
- 각각의 필드(닉네임, 자기소개, 포지션, 실력)가 기존 값이랑 동일하면 변경되지 않도록 설정

resolved : #250 
