### PR TITLE
#241 채팅 리스트 로직 수정, s3bucket 에 저장가능한 이미지 확장자 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.projectlombok:lombok:1.18.28'
+    testImplementation 'junit:junit:4.13.1'
 
-	runtimeOnly "com.mysql:mysql-connector-j" // mysql
+    runtimeOnly "com.mysql:mysql-connector-j" // mysql
 	runtimeOnly 'com.h2database:h2' // h2
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/Response/ChatRoomDTO.java
@@ -44,4 +44,8 @@ public class ChatRoomDTO implements Serializable {
     public void updatecourtId(Long courtId){
         this.courtId = courtId;
     }
+
+    public void updatePartnerId(String pid){
+        this.partnerId = pid;
+    }
 }

--- a/src/main/java/sync/slamtalk/common/s3bucket/repository/AwsS3RepositoryImpl.java
+++ b/src/main/java/sync/slamtalk/common/s3bucket/repository/AwsS3RepositoryImpl.java
@@ -216,8 +216,8 @@ public class AwsS3RepositoryImpl implements AwsS3Repository{
     private void extensionValidator(MultipartFile multipartFile){
         String contentType = multipartFile.getContentType();
 
-        // 확장자가 jpeg,png 인 파일들만 받아서 처리
-        if(ObjectUtils.isEmpty(contentType) || (!contentType.contains("image/jpeg") && !contentType.contains("image/png"))){
+        // 확장자가 jpeg,png,jpg 인 파일들만 받아서 처리
+        if(ObjectUtils.isEmpty(contentType) || (!contentType.contains("image/jpeg") && !contentType.contains("image/png")) && !contentType.contains("image/jpg")){
             throw new BaseException(ErrorResponseCode.S3_BUCKET_INVALID_EXTENSION);
         }
     }

--- a/src/test/java/sync/slamtalk/chat/repository/UserChatRoomRepositoryTest.java
+++ b/src/test/java/sync/slamtalk/chat/repository/UserChatRoomRepositoryTest.java
@@ -1,14 +1,29 @@
 package sync.slamtalk.chat.repository;
 
 import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import sync.slamtalk.chat.entity.ChatRoom;
+import sync.slamtalk.chat.entity.RoomType;
+import sync.slamtalk.chat.entity.UserChatRoom;
+import sync.slamtalk.user.UserRepository;
+import sync.slamtalk.user.dto.request.UserSignUpReq;
+import sync.slamtalk.user.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
+@Slf4j
 class UserChatRoomRepositoryTest {
 
     @Autowired
@@ -17,64 +32,79 @@ class UserChatRoomRepositoryTest {
     @Autowired
     private UserChatRoomRepository userChatRoomRepository;
 
+    public String email = "test1@naver.com";
+    public String password = "123@password!";
+    public String nickname = "nickname";
+
+
+    @BeforeEach
+    void beforeSet(){
+        // user
+        User user = new UserSignUpReq(email, password, nickname).toEntity();
+        entityManager.persist(user);
+
+        // chatroom
+        ChatRoom c1 = ChatRoom.builder()
+                .name("농구방")
+                .roomType(RoomType.BASKETBALL)
+                .build();
+        ChatRoom c2 = ChatRoom.builder()
+                .name("같이해요방")
+                .roomType(RoomType.TOGETHER)
+                .build();
+        ChatRoom c3 = ChatRoom.builder()
+                .name("팀매칭")
+                .roomType(RoomType.MATCHING)
+                .build();
+
+        entityManager.persist(c1);
+        entityManager.persist(c2);
+        entityManager.persist(c3);
+
+        // userChatRoom
+        UserChatRoom usc1 = UserChatRoom.builder()
+                .user(user)
+                .chat(c1)
+                .readIndex(0L)
+                .build();
+        UserChatRoom usc2 = UserChatRoom.builder()
+                .user(user)
+                .chat(c2)
+                .readIndex(0L)
+                .build();
+        UserChatRoom usc3 = UserChatRoom.builder()
+                .user(user)
+                .chat(c3)
+                .readIndex(0L)
+                .build();
+        entityManager.persist(usc1);
+        entityManager.persist(usc2);
+        entityManager.persist(usc3);
+
+    }
+
     @Test
     void findByChat_Id() {
+        List<UserChatRoom> userChatRoomList = userChatRoomRepository.findByChat_Id(1L);
+
+        for(UserChatRoom ucr : userChatRoomList){
+            System.out.println("채팅방이름: "+ucr.getName());
+        }
+
+        assertTrue(!userChatRoomList.isEmpty());
     }
 
     @Test
     void findByUser_Id() {
+        List<UserChatRoom> userChatRoomRepositoryByUserId = userChatRoomRepository.findByUser_Id(1L);
+        assertTrue(userChatRoomRepositoryByUserId.size()==3);
+
     }
 
     @Test
     void findByUserChatroom() {
-        // user
-
-//        UserSignUpRequestDto usd=new UserSignUpRequestDto();
-//        User user = User.from(usd);
-//        entityManager.persist(user);
-
-
-        // chatroom
-//        ChatRoom c1 = ChatRoom.builder()
-//                .name("농구방")
-//                .roomType(RoomType.BASKETBALL)
-//                .build();
-//        ChatRoom c2 = ChatRoom.builder()
-//                .name("같이해요방")
-//                .roomType(RoomType.TOGETHER)
-//                .build();
-//        ChatRoom c3 = ChatRoom.builder()
-//                .name("팀매칭")
-//                .roomType(RoomType.MATCHING)
-//                .build();
-//
-//        entityManager.persist(c1);
-//        entityManager.persist(c2);
-//        entityManager.persist(c3);
-//
-//        // userChatRoom
-//        UserChatRoom usc1 = UserChatRoom.builder()
-//                .user(user)
-//                .chat(c1)
-//                .readIndex(0L)
-//                .build();
-//        UserChatRoom usc2 = UserChatRoom.builder()
-//                .user(user)
-//                .chat(c2)
-//                .readIndex(0L)
-//                .build();
-//        UserChatRoom usc3 = UserChatRoom.builder()
-//                .user(user)
-//                .chat(c3)
-//                .readIndex(0L)
-//                .build();
-//        entityManager.persist(usc1);
-//        entityManager.persist(usc2);
-//        entityManager.persist(usc3);
-//
-//        Optional<UserChatRoom> userChatRoom = userChatRoomRepository.findByUserChatroom(user.getId(), c2.getId());
-//        assertTrue(userChatRoom.isPresent(),"존재합니다");
-
+        Optional<UserChatRoom> byUserChatroom = userChatRoomRepository.findByUserChatroom(1L, 3L);
+        assertTrue(byUserChatroom.isPresent(),"존재합니다");
 
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 채팅리스트에서 팀매칭 채팅방 상대방 유저의 이름이 아니라 채팅방 이름자체가 뜨도록 수정
- 채팅방 리스트 api 코드 수정
- s3bucket 에 허용되는 파일 확장자 추가
