### PR TITLE
#241 채팅방 중복 생성 버그 수정

### DIFF
--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -72,7 +72,7 @@ public class ChatServiceImpl implements ChatService{
                 // B유저의 채팅방 중 roomType = DIRECT && directId 가 A유저
 
                 // A 유저, B 유저 모두 삭제 하지 않은 경우
-                if(optionalChatRoom_1.get().getIsDeleted() && optionalChatRoom_2.get().getIsDeleted()){
+                if(!optionalChatRoom_1.get().getIsDeleted() && !optionalChatRoom_2.get().getIsDeleted()){
                     // A유저 B유저 모두 동일한 채팅방 아이디를 가지고 있을 것이기 때문
                     return optionalChatRoom_1.get().getChat().getId();
                 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- 모두 삭제하지 않은 경우에만(isDelete = false) 기존의 채팅방 아이디 반환하도록 수정
