### PR TITLE
상대팀매칭, 메이트찾기 content(내용) 필드255자 제한 수정

### DIFF
--- a/src/main/java/sync/slamtalk/mate/entity/MatePost.java
+++ b/src/main/java/sync/slamtalk/mate/entity/MatePost.java
@@ -45,6 +45,7 @@ public class MatePost extends BaseEntity implements Post{
         @Column(nullable = false)
         private String title; // 글 제목
 
+        @Lob
         @Column(nullable = false)
         private String content; // 글 내용
 

--- a/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
+++ b/src/main/java/sync/slamtalk/team/entity/TeamMatching.java
@@ -56,6 +56,7 @@ public class TeamMatching extends BaseEntity implements Post {
     @Column(nullable = false)
     private String title;
 
+    @Lob
     @Column(nullable = false)
     private String content;
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
-  [] content 필드를 기존 String 타입으로 인한 255자 제한에서 @lob 어노테이션 추가하여 제한을 풀었음.