### PR TITLE
bug : ChatErrorResponseCode 메소드 수정,과거 내역 추가 요청 컨트롤러/서비스코드 수정

### DIFF
--- a/src/main/java/sync/slamtalk/chat/controller/ChatController.java
+++ b/src/main/java/sync/slamtalk/chat/controller/ChatController.java
@@ -95,8 +95,8 @@ public class ChatController {
             description = "이 기능은 과거 마지막으로 읽은 메세지 전의 메세지를 보내주는 기능입니다.",
             tags = {"채팅"}
     )
-    public ApiResponse<List<ChatMessageDTO>> getChatPastHistory(@Param("roomId") Long roomId, @AuthenticationPrincipal Long userId, @Param("count") int count) {
-        return ApiResponse.ok(chatService.getPreviousChatMessages(userId, roomId, count));
+    public ApiResponse<List<ChatMessageDTO>> getChatPastHistory(@Param("roomId") Long roomId, @AuthenticationPrincipal Long userId, @Param("lastMessageId") Long lastMessageId) {
+        return ApiResponse.ok(chatService.getPreviousChatMessages(userId, roomId, lastMessageId));
     }
 
 

--- a/src/main/java/sync/slamtalk/chat/dto/ChatErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/chat/dto/ChatErrorResponseCode.java
@@ -33,16 +33,16 @@ public enum ChatErrorResponseCode implements ResponseCodeDetails {
 
     @Override
     public int getStatus() {
-        return 0;
+        return this.status;
     }
 
     @Override
     public int getCode() {
-        return 0;
+        return this.code;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return this.message;
     }
 }

--- a/src/main/java/sync/slamtalk/chat/redis/RedisService.java
+++ b/src/main/java/sync/slamtalk/chat/redis/RedisService.java
@@ -59,7 +59,7 @@ public class RedisService {
 
 
     // 메세지 가져오기
-    public List<ChatMessageDTO> getMessages(Long roomId, Long readIndex) {
+    public List<ChatMessageDTO> getMessages(Long roomId, Long lastMessageId) {
 
 
         List<ChatMessageDTO> chatList = new ArrayList<>();
@@ -67,6 +67,7 @@ public class RedisService {
         // 검색 key 생성
         // 특정 채팅방 메세지 모두 가져오기
         String messageKey = "chat_room:" + roomId + "*";
+
         // 디버그용
         //log.debug("=========> messageKey : {}",messageKey);
         Set<String> keys = stringRedisTemplate.keys(messageKey);
@@ -81,18 +82,17 @@ public class RedisService {
         }
 
 
-        log.debug("== readIndex : {}", readIndex);
+        log.debug("== lastMessageId : {}", lastMessageId);
 
         List<String> keyCollect = sortedKeys.stream()
                 .map(key -> key.split(":"))
-                // 분할된 배열에서 메시지 ID가 숫자 형태인지, 그리고 readIndex보다 작은지 확인
-                .filter(parts -> parts.length == 4 && parts[3].matches("\\d+") && Long.parseLong(parts[3]) <= readIndex)
+                // 분할된 배열에서 메시지 ID가 숫자 형태인지, 그리고 lastMessageId보다 작은지 확인
+                .filter(parts -> parts.length == 4 && parts[3].matches("\\d+") && Long.parseLong(parts[3]) <= lastMessageId)
                 // 원래 키 형태로 복원
                 .map(parts -> String.join(":", parts))
                 // 메시지 ID에 따라 내림차순 정렬
-                //.sorted((key1, key2) -> Integer.compare(Integer.parseInt(key2.split(":")[3]), Integer.parseInt(key1.split(":")[3])))
-                // 상위 20개만 선택
-                .limit(20)
+                // 상위 30개만 선택
+                .limit(30)
                 .collect(Collectors.toList());
 
         for (String key : keyCollect) {

--- a/src/main/java/sync/slamtalk/chat/service/ChatService.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatService.java
@@ -45,7 +45,7 @@ public interface ChatService {
 
 
     // 과거 내역 요청
-    List<ChatMessageDTO> getPreviousChatMessages(Long userId, Long chatRoomId, int count);
+    List<ChatMessageDTO> getPreviousChatMessages(Long userId, Long chatRoomId, Long lastMessageId);
 
 
     // 사용자 채팅리스트 가져오기
@@ -65,6 +65,6 @@ public interface ChatService {
 
 
     // Redis 조회 후 DB 조회
-    Optional<List<ChatMessageDTO>> redisFirstDataBaseLater(Long userId, Long chatRoomId, int count);
+    Optional<List<ChatMessageDTO>> redisFirstDataBaseLater(Long userId, Long chatRoomId, Long lastMessageId);
 
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- ChatErrorResponseCode 에서 클래스 값 접근 메서드 반환값 수정
- 채팅방 접속 후 과거 내역 추가 요청 시 lastMessageId 를 기준으로 페이징
- 과거 내역 요청 api 파라미터 변경, 관련 서비스 코드 변경

