### PR TITLE
채팅방 새로운 메세지 알림 외

### DIFF
--- a/src/main/java/sync/slamtalk/chat/config/ChatInboundInterceptor.java
+++ b/src/main/java/sync/slamtalk/chat/config/ChatInboundInterceptor.java
@@ -21,6 +21,7 @@ import sync.slamtalk.user.entity.User;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,6 +37,7 @@ public class ChatInboundInterceptor implements ChannelInterceptor {
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final StompHandler stompHandler;
+
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -203,6 +205,10 @@ public class ChatInboundInterceptor implements ChannelInterceptor {
                     log.debug("=== MESSAGE 저장 완료 ===");
                 }
             }
+            // 메세지 발행시 마다 알림 추가?
+
+            // FIXME 일단 추가, 추후 삭제 하거나 유지
+            chatService.notificationMessage(roomId);
             log.debug("=== 메세지 발송 완료 ===");
         }
 

--- a/src/main/java/sync/slamtalk/chat/dto/request/ChatMessageDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/request/ChatMessageDTO.java
@@ -15,17 +15,16 @@ import java.io.Serializable;
 @Builder(access = AccessLevel.PUBLIC)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChatMessageDTO implements Serializable {
-    //@NotNull
     private String messageId; // 메세지 아이디
-    //@NotNull
+
     private String roomId; // 채팅방 아이디(채팅방 식별자)
-    //@NotNull
+
     private Long senderId; // 메세지를 보낸 사용자의 아이디
-    //@NotNull
+
     private String senderNickname; // 메세지를 보낸 사용자의 닉네임 -> 채팅방에 표시될
-    //@NotNull
+
     private String imgUrl; // 메세지를 보낸 사용자의 프로필
-    //@NotNull
+
     private String content; // 메세지 내용
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private String timestamp; // 메세지를 보낸 시간

--- a/src/main/java/sync/slamtalk/chat/dto/request/ChatMessageDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/request/ChatMessageDTO.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 
 @Getter
@@ -29,5 +30,17 @@ public class ChatMessageDTO implements Serializable {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private String timestamp; // 메세지를 보낸 시간
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageId);
+    }
 
+    @Override
+    public boolean equals(Object obj) {
+        if(this==obj) return true;
+        if(obj == null || getClass() != obj.getClass())return false;
+
+        ChatMessageDTO that = (ChatMessageDTO) obj;
+        return Objects.equals(messageId,that.messageId);
+    }
 }

--- a/src/main/java/sync/slamtalk/chat/dto/response/ChatRoomDTO.java
+++ b/src/main/java/sync/slamtalk/chat/dto/response/ChatRoomDTO.java
@@ -30,11 +30,17 @@ public class ChatRoomDTO implements Serializable {
     // 채팅방 마지막 메세지 날짜
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private String lastMessageTime;
+    // 읽지 않은 메세지 표시
+    private boolean newMsg = false;
 
 
     // 채팅방 마지막 메세지 업데이트
     public void setLast_message(String lastMessage) {
         this.lastMessage = lastMessage;
+    }
+
+    public void updateNoReadCnt(Boolean newMsg) {
+        this.newMsg = newMsg;
     }
 
     public void updateName(String name) {

--- a/src/main/java/sync/slamtalk/chat/service/ChatService.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatService.java
@@ -37,6 +37,8 @@ public interface ChatService {
     void saveReadIndex(Long userId, Long chatRoomId, Long readIndex);
 
 
+    void notificationMessage(Long roomId);
+
     // 특정 방에서 주고 받은 모든 메세지 가져오기
     // 페이징 방식에 의존
     //      1. 사용자가 입장한 시점의 채팅방 메세지부터 모두 내려주기

--- a/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
+++ b/src/main/java/sync/slamtalk/chat/service/ChatServiceImpl.java
@@ -160,7 +160,7 @@ public class ChatServiceImpl implements ChatService {
             log.debug("userChatRoom 저장 완료 : {}", savedUserChatRoom.getChat().getId());
         }
 
-        // 테스트용 임시
+        // 생성 완료에 따른 알림
         for(Long id : participants){
             log.debug("알림을 줄 참여자 아이디 : {}",id);
             NotificationRequest req = NotificationRequest.of("채팅방이 생성되었습니다","",Set.of(id));
@@ -169,15 +169,18 @@ public class ChatServiceImpl implements ChatService {
         return roomNum;
     }
 
+    /**
+     * 특정 채팅방에 참여하고 있는 유저들에게 새로운 메세지 알림
+     *
+     * @param  roomId : 채팅방 Id
+     */
     @Override
     public void notificationMessage(Long roomId) {
-        // 채팅방가지고 있는 userChatRoom 유저들에게 알림전달
-        // 잠시 보류
-//        List<UserChatRoom> userChatRooms = userChatRoomRepository.findByChat_Id(roomId);
-//        for(UserChatRoom u : userChatRooms){
-//            NotificationRequest req = NotificationRequest.of("새로운 메세지가 도착했습니다.","",Set.of(u.getUser().getId()));
-//            notificationSender.send(req);
-//        }
+        List<UserChatRoom> userChatRooms = userChatRoomRepository.findByChat_Id(roomId);
+        for(UserChatRoom u : userChatRooms){
+            NotificationRequest req = NotificationRequest.of("새로운 메세지가 도착했습니다.","",Set.of(u.getUser().getId()));
+            notificationSender.send(req);
+        }
     }
 
     /**

--- a/src/main/java/sync/slamtalk/notification/model/NotificationContent.java
+++ b/src/main/java/sync/slamtalk/notification/model/NotificationContent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sync.slamtalk.common.BaseEntity;
 
 /**
  * 알림의 내용을 담고 있는 Entity
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NotificationContent {
+public class NotificationContent extends BaseEntity {
 
 	@Id
 	@Column(name = "notification_content_id")


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

‼️‼️ @sbslc2000 님이 작성한 코드 수정
NotificationContent 에 BaseEntity 상속
이유 : create_at 사용 시 BaseEntity 상속 필요함, NotificationContent 에는 별도 속성 x

- 채팅방 리스트 API 새로운 메세지 속성 추가
- 채팅 알림(새로운 방 생성, 새로운 메세지 발생)
- 팀매칭 채팅방 유저 프로필 추가
- 과거 메세지 추가적으로 페이징할 경우 중복처리 로직 추가, ChatMessageDTO 수정

