### PR TITLE
#324 회원 탈퇴 구현 

### DIFF
--- a/src/main/java/sync/slamtalk/security/config/SecurityConstants.java
+++ b/src/main/java/sync/slamtalk/security/config/SecurityConstants.java
@@ -1,0 +1,29 @@
+package sync.slamtalk.security.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityConstants {
+    public static final List<String> EXCLUDE_URLS = List.of(
+            "/api/login",
+            "/api/sign-up",
+            "/api/tokens/refresh",
+            "/api/logout",
+            "/ws/slamtalk",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/favicon.ico",
+            "/api/map/courts",
+            "/api/send-mail",
+            "/api/mail-check",
+            "/api/user/temporary-passwords",
+            "/api/mate/read",
+            "/api/mate/list",
+            "/api/match/read",
+            "/api/match/list",
+            "/api/test/sign-up"
+    );
+}

--- a/src/main/java/sync/slamtalk/security/jwt/JwtFilter.java
+++ b/src/main/java/sync/slamtalk/security/jwt/JwtFilter.java
@@ -12,9 +12,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import sync.slamtalk.security.config.SecurityConstants;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Jwt를 위한 커스텀 필터
@@ -25,8 +25,6 @@ import java.util.List;
 public class JwtFilter extends OncePerRequestFilter { // BaseAuthoriFilter // permitAll 관련
    @Value("${jwt.access.header}")
    public String authorizationHeader;
-   @Value("${app.exception-paths}")
-   private List<String> EXCEPTION_PATHS;
    @Value("${jwt.refresh.header}")
    public String refreshAuthorizationHeader;
    private final JwtTokenProvider tokenProvider;
@@ -47,7 +45,7 @@ public class JwtFilter extends OncePerRequestFilter { // BaseAuthoriFilter // pe
       String requestURI = httpServletRequest.getRequestURI();
 
       // EXCEPTION_PATHS 경로에 있는 것들은 토큰 검사 안함.
-      for(String exceptionPath : EXCEPTION_PATHS){
+      for(String exceptionPath : SecurityConstants.EXCLUDE_URLS){
          if(httpServletRequest.getRequestURI().contains(exceptionPath)){
             log.trace("이 페이지는 검사 안함 : {}", httpServletRequest.getRequestURI());
             filterChain.doFilter(httpServletRequest, httpServletResponse);
@@ -55,8 +53,6 @@ public class JwtFilter extends OncePerRequestFilter { // BaseAuthoriFilter // pe
          }
       }
 
-
-      // TODO : 로그인, 회원가입, 리프레쉬, 로그아웃 시 URL 안거치게 하는 로직 추가하기
 
       // 1. Request header accessToken 토큰 추출 및 유효성 검사
       if (StringUtils.hasText(accessToken) && tokenProvider.validateToken(accessToken)) {

--- a/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -67,7 +67,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         setRefreshTokenCookie(response, refreshToken);
 
-//        response.sendRedirect("http://localhost:3000/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
+        //로컬 개발용
+        //JwtTokenDto token = jwtTokenProvider.createToken(user);
+        //response.sendRedirect("http://localhost:3000/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck() + "&token=" + token.getAccessToken());
+
+        // 서버용
         response.sendRedirect("https://www.slam-talk.site/social-login?loginSuccess=true&firstLoginCheck=" + user.getFirstLoginCheck());
 
         // 최초 정보수집을 위해 jwtTokenResponseDto의 firstLoginCheck은 true 로 반환, 이후는 false 로 반환하기 위한 로직

--- a/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
@@ -70,16 +70,19 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // socialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
         OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
 
-        User createdUser = getUser(extractAttributes, socialType); // getUser() 메소드로 User 객체 생성 후 반환
+        User user = getUser(extractAttributes, socialType); // getUser() 메소드로 User 객체 생성 후 반환
+
+        // 소셜 엑세스 토큰 저장하는 로직 추가
+        user.updateOauth2AccessToken(userRequest.getAccessToken().getTokenValue());
 
         // DefaultOAuth2User를 구현한 CustomOAuth2User 객체를 생성해서 반환
         return new CustomOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority(createdUser.getRole().getKey())),
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())),
                 attributes,
                 extractAttributes.getNameAttributeKey(),
-                createdUser.getEmail(),
-                createdUser.getRole(),
-                createdUser.getSocialType()
+                user.getEmail(),
+                user.getRole(),
+                user.getSocialType()
         );
     }
 

--- a/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/sync/slamtalk/security/oauth2/service/CustomOAuth2UserService.java
@@ -17,6 +17,7 @@ import sync.slamtalk.security.oauth2.OAuthAttributes;
 import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.service.NicknameService;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/sync/slamtalk/user/controller/AuthController.java
+++ b/src/main/java/sync/slamtalk/user/controller/AuthController.java
@@ -135,13 +135,14 @@ public class AuthController {
         return ApiResponse.ok();
     }
 
-    @DeleteMapping("/user/delete")
+    @DeleteMapping("/user")
     @Operation(
             summary = "회원 탈퇴",
-            description = "7일이내로 회원탈퇴과정이 진행되고, 회원탈퇴 클릭 시 재회원가입, 로그인이 불가능하다."
+            description = "회원 탈퇴 시 모든 유저의 정보가 사라진다"
     )
-    public ApiResponse<Void> cancelUser(@AuthenticationPrincipal Long userId) {
-        authService.cancelUser(userId);
+    public ApiResponse<Void> userWithdrawal(@AuthenticationPrincipal Long userId) {
+        authService.userWithdrawal(userId);
         return ApiResponse.ok();
     }
+
 }

--- a/src/main/java/sync/slamtalk/user/controller/AuthController.java
+++ b/src/main/java/sync/slamtalk/user/controller/AuthController.java
@@ -140,8 +140,12 @@ public class AuthController {
             summary = "회원 탈퇴",
             description = "회원 탈퇴 시 모든 유저의 정보가 사라진다"
     )
-    public ApiResponse<Void> userWithdrawal(@AuthenticationPrincipal Long userId) {
-        authService.userWithdrawal(userId);
+    public ApiResponse<Void> userWithdrawal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @AuthenticationPrincipal Long userId
+    ) {
+        authService.userWithdrawal(request, response, userId);
         return ApiResponse.ok();
     }
 

--- a/src/main/java/sync/slamtalk/user/dto/response/UserDetailsOtherInfo.java
+++ b/src/main/java/sync/slamtalk/user/dto/response/UserDetailsOtherInfo.java
@@ -1,6 +1,7 @@
 package sync.slamtalk.user.dto.response;
 
 import lombok.*;
+import sync.slamtalk.user.entity.SocialType;
 import sync.slamtalk.user.entity.User;
 import sync.slamtalk.user.utils.UserLevelScore;
 
@@ -13,6 +14,7 @@ public class UserDetailsOtherInfo {
     private Long id;
     private String nickname;
     private String imageUrl;
+    private SocialType socialType;
 
     /* 마이페이지 기능 */
     private String selfIntroduction;
@@ -47,6 +49,7 @@ public class UserDetailsOtherInfo {
                 user.getId(),
                 user.getNickname(),
                 user.getImageUrl(),
+                user.getSocialType(),
                 user.getSelfIntroduction(),
                 basketballSkillLevel,
                 basketballPosition,

--- a/src/main/java/sync/slamtalk/user/entity/SocialType.java
+++ b/src/main/java/sync/slamtalk/user/entity/SocialType.java
@@ -1,5 +1,5 @@
 package sync.slamtalk.user.entity;
 
 public enum SocialType {
-    LOCAL, KAKAO, NAVER, GOOGLE
+    LOCAL, KAKAO, NAVER, GOOGLE, NONE
 }

--- a/src/main/java/sync/slamtalk/user/entity/User.java
+++ b/src/main/java/sync/slamtalk/user/entity/User.java
@@ -3,7 +3,6 @@ package sync.slamtalk.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -24,7 +23,6 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(of = "id", callSuper = false)
 @SQLDelete(sql = "UPDATE users SET is_deleted = true, refresh_token = null  WHERE id = ?")
-@SQLRestriction("is_deleted <> true")
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public class User extends BaseEntity implements UserDetails {
@@ -37,9 +35,7 @@ public class User extends BaseEntity implements UserDetails {
     private String password;
     @Column(nullable = false, unique = true)
     private String nickname;
-    @Column(nullable = false)
     private String email;
-    @Column(nullable = false)
     private String imageUrl;
     @Column
     private String refreshToken;
@@ -146,6 +142,20 @@ public class User extends BaseEntity implements UserDetails {
                 .build();
     }
 
+    public void userWithdrawal(String newNickname) {
+        delete();
+        this.nickname = newNickname;
+        this.password = null;
+        this.email = null;
+        this.imageUrl = null;
+        this.socialId = null;
+        this.socialType = SocialType.NONE;
+        this.refreshToken = null;
+        this.selfIntroduction = null;
+        this.basketballSkillLevel = null;
+        this.basketballPosition = null;
+    }
+
     /**
      * 리프레쉬 토큰 update하는 메서드
      *
@@ -217,6 +227,8 @@ public class User extends BaseEntity implements UserDetails {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+
 
     /* UserDetails 관련 메서드 */
     @Override

--- a/src/main/java/sync/slamtalk/user/entity/User.java
+++ b/src/main/java/sync/slamtalk/user/entity/User.java
@@ -2,7 +2,6 @@ package sync.slamtalk.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -22,7 +21,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(of = "id", callSuper = false)
-@SQLDelete(sql = "UPDATE users SET is_deleted = true, refresh_token = null  WHERE id = ?")
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public class User extends BaseEntity implements UserDetails {
@@ -49,6 +47,9 @@ public class User extends BaseEntity implements UserDetails {
     private SocialType socialType;
     @Column
     private String socialId;
+
+    @Column
+    private String oauth2AccessToken;
 
     /* 마이페이지 기능 */
     @Column
@@ -154,6 +155,7 @@ public class User extends BaseEntity implements UserDetails {
         this.selfIntroduction = null;
         this.basketballSkillLevel = null;
         this.basketballPosition = null;
+        this.oauth2AccessToken = null;
     }
 
     /**
@@ -228,7 +230,17 @@ public class User extends BaseEntity implements UserDetails {
         this.password = password;
     }
 
-
+    /**
+     * 이 메소드는 OAuth2 인증을 위해 사용자의 액세스 토큰을 업데이트합니다.
+     * OAuth2 인증 절차에서 액세스 토큰은 사용자의 인증 정보를 서버에 제공하는 중요한 역할을 합니다.
+     * 새로운 액세스 토큰이 발급되었을 때 이 메소드를 호출하여 기존 토큰을 새 토큰으로 교체합니다.
+     *
+     * @param oauth2AccessToken 새로 발급받은 OAuth2 액세스 토큰. 이 토큰은 사용자의 인증 상태를 나타내며,
+     *                          API 요청 시 인증 헤더에 포함되어야 합니다.
+     */
+    public void updateOauth2AccessToken(String oauth2AccessToken){
+        this.oauth2AccessToken = oauth2AccessToken;
+    }
 
     /* UserDetails 관련 메서드 */
     @Override

--- a/src/main/java/sync/slamtalk/user/error/UserErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/user/error/UserErrorResponseCode.java
@@ -16,7 +16,9 @@ public enum UserErrorResponseCode implements ResponseCodeDetails {
     ATTENDANCE_ALREADY_EXISTS(SC_BAD_REQUEST, 4008, "하루에 한번만 출석이 가능합니다."),
     UNVERIFIED_EMAIL(SC_BAD_REQUEST, 4009, "이메일 인증을 하지 않았습니다"),
     ALREADY_CANCEL_USER(SC_BAD_REQUEST, 4010, "회원탈퇴 후 7일 동안 재가입이 불가능합니다"),
-    FAILED_TO_CREATE_TEMPORARY_PASSWORD_ISSUANCE(SC_INTERNAL_SERVER_ERROR, 4011, "임시 비밀번호 재발급이 실패하였습니다");
+    FAILED_TO_CREATE_TEMPORARY_PASSWORD_ISSUANCE(SC_INTERNAL_SERVER_ERROR, 4011, "임시 비밀번호 재발급이 실패하였습니다"),
+    NEED_TO_LOG_IN_AGAIN(SC_BAD_REQUEST, 4012, "회원 탈퇴를 진행하기 위해서는 다시 로그인해야 합니다."),
+    SOCIAL_TYPE_DOESNT_EXIST(SC_BAD_REQUEST, 4013, "잘못된 접근입니다");
     ;
 
     private final int code;

--- a/src/main/java/sync/slamtalk/user/service/AuthService.java
+++ b/src/main/java/sync/slamtalk/user/service/AuthService.java
@@ -1,14 +1,18 @@
 package sync.slamtalk.user.service;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sync.slamtalk.chat.redis.RedisService;
@@ -16,6 +20,7 @@ import sync.slamtalk.common.BaseException;
 import sync.slamtalk.email.EmailService;
 import sync.slamtalk.security.dto.JwtTokenDto;
 import sync.slamtalk.security.jwt.JwtTokenProvider;
+import sync.slamtalk.security.logout.CustomLogoutHandler;
 import sync.slamtalk.security.utils.CookieUtil;
 import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.dto.request.UserLoginReq;
@@ -44,7 +49,9 @@ public class AuthService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider tokenProvider;
     private final EmailService emailService;
+    private final RevokeSocialLoginService revokeSocialLoginService;
     private final NicknameService nicknameService;
+    private final CustomLogoutHandler customLogoutHandler;
     @Value("${jwt.access.header}")
     public String accessAuthorizationHeader;
     @Value("${jwt.access.expiration}")
@@ -180,17 +187,41 @@ public class AuthService {
     }
 
     /**
-     * 회원 탈퇴
+     * 사용자 계정 탈퇴 처리를 위한 메소드입니다. 이 메소드는 전달받은 사용자 ID를 기반으로 사용자를 찾아 탈퇴 처리합니다.
+     * 탈퇴 처리 과정에서는 먼저 사용자의 소셜 로그인 계정을 해지하고, 로그아웃 처리를 진행한 후,
+     * 탈퇴한 사용자의 닉네임을 재설정합니다. 이 메소드는 @Transactional 어노테이션을 통해
+     * 전체 프로세스가 하나의 트랜잭션으로 관리되어, 중간에 오류가 발생할 경우 모든 작업이 롤백됩니다.
      *
-     * @param userId : 탈퇴하고자 하는 USER
+     * @param request  현재 요청의 HttpServletRequest 객체입니다. 사용자 로그아웃 처리에 사용됩니다.
+     * @param response 현재 응답의 HttpServletResponse 객체입니다. 사용자 로그아웃 처리에 사용됩니다.
+     * @param userId   탈퇴를 요청한 사용자의 고유 ID입니다. 이 ID를 통해 사용자 정보를 조회하고 탈퇴 처리를 진행합니다.
+     * @throws BaseException 사용자를 찾을 수 없는 경우에 발생합니다. 이 예외는 NOT_FOUND_USER 에러 코드와 함께 발생합니다.
+     *                       사용자의 소셜 타입에 따라 구글, 네이버, 카카오 계정 해지에 실패할 경우에도 발생할 수 있습니다.
      */
     @Transactional
     public void userWithdrawal(
+            HttpServletRequest request,
+            HttpServletResponse response,
             Long userId
     ) {
+        // 사용자 ID를 통해 사용자 정보를 조회합니다. 사용자를 찾을 수 없는 경우, BaseException 예외를 발생시킵니다.
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
 
+        // 사용자의 소셜 로그인 타입에 따라 해당 소셜 계정의 연동을 해제합니다.
+        switch (user.getSocialType()) {
+            case GOOGLE -> revokeSocialLoginService.deleteGoogleAccount(user);
+            case NAVER -> revokeSocialLoginService.deleteNaverAccount(user);
+            case KAKAO -> revokeSocialLoginService.deleteKakaoAccount(user);
+            default -> {
+                break; // 소셜 로그인이 아닐 경우 연동해지가 필요없음.
+            }
+        }
+
+        // 사용자를 로그아웃 처리합니다.
+        logoutUser(request, response);
+
+        // 탈퇴한 사용자의 닉네임을 재설정합니다.
         user.userWithdrawal(nicknameService.createANicknameForDeletedUser());
     }
 
@@ -206,6 +237,7 @@ public class AuthService {
         user.updatePassword(passwordEncoder.encode(password));
 
     }
+
 
     /**
      * 사용자에게 임시 비밀번호를 발급하여 이메일로 전송하는 메서드입니다.
@@ -314,6 +346,40 @@ public class AuthService {
                 refreshTokenExpirationPeriod,
                 domain
         );
+    }
+
+    /**
+     * 현재 로그인한 사용자를 로그아웃 처리하는 메서드입니다.
+     * 이 메서드는 사용자의 인증 정보를 받아 로그아웃 처리를 수행하고,
+     * 필요한 경우 추가적인 로그아웃 관련 처리(예: 쿠키 삭제)를 수행합니다.
+     *
+     * @param request 사용자의 요청 정보를 담고 있는 HttpServletRequest 객체입니다.
+     *                이 객체를 통해 사용자의 요청 및 세션 정보에 접근할 수 있습니다.
+     * @param response 서버의 응답 정보를 담고 있는 HttpServletResponse 객체입니다.
+     *                 이 객체를 통해 로그아웃 처리 후의 응답 상태 코드 설정 및 쿠키 삭제 등의 응답 관련 처리를 수행할 수 있습니다.
+     *
+     * 이 메서드는 사용자의 인증 정보를 SecurityContextHolder의 컨텍스트에서 가져와 해당 사용자를 로그아웃 처리합니다.
+     * 로그아웃 처리가 성공적으로 이루어지면, 응답 상태 코드로 HttpStatus.OK(200) 값을 설정하고,
+     * JSESSIONID 쿠키를 삭제하여 클라이언트의 세션을 종료시킵니다.
+     *
+     * 로그아웃 처리 과정 중에 추가적인 로그아웃 관련 처리가 필요한 경우,
+     * 이 부분에 해당 처리 로직을 구현할 수 있습니다. 예를 들어, 특정 쿠키를 삭제하거나,
+     * 로그아웃 이벤트를 로깅하는 등의 처리를 추가할 수 있습니다.
+     *
+     * @return 이 메서드는 반환값이 없습니다(void).
+     */
+    private void logoutUser(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null) {
+            new SecurityContextLogoutHandler().logout(request, response, auth);
+        }
+
+        // 필요한 경우, 여기에서 쿠키 삭제 등의 추가적인 로그아웃 관련 처리를 할 수 있습니다.
+        response.setStatus(HttpStatus.OK.value());
+        response.addCookie(new Cookie("JSESSIONID", null)); // JSESSIONID 쿠키 삭제
     }
 
 }

--- a/src/main/java/sync/slamtalk/user/service/AuthService.java
+++ b/src/main/java/sync/slamtalk/user/service/AuthService.java
@@ -26,7 +26,6 @@ import sync.slamtalk.user.error.UserErrorResponseCode;
 import sync.slamtalk.user.utils.PasswordGenerator;
 
 import java.util.Optional;
-import java.util.StringJoiner;
 
 import static sync.slamtalk.user.error.UserErrorResponseCode.ALREADY_CANCEL_USER;
 
@@ -45,6 +44,7 @@ public class AuthService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider tokenProvider;
     private final EmailService emailService;
+    private final NicknameService nicknameService;
     @Value("${jwt.access.header}")
     public String accessAuthorizationHeader;
     @Value("${jwt.access.expiration}")
@@ -185,28 +185,13 @@ public class AuthService {
      * @param userId : 탈퇴하고자 하는 USER
      */
     @Transactional
-    public void cancelUser(
+    public void userWithdrawal(
             Long userId
     ) {
-        // todo : 소셜 로그인일 경우 별도의 처리가 필요하다!
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
-        SocialType socialType = user.getSocialType();
 
-  /*      if(socialType.equals(SocialType.KAKAO)){
-            revokeService.deleteKakaoAccount(user);
-        }*/ /*else if (socialType.equals(SocialType.GOOGLE)){
-            revokeService.deleteGoogleAccount(user, accessToken);
-        } else if (socialType.equals(SocialType.NAVER)) {
-            revokeService.deleteNaverAccount(user, accessToken);
-        }*/
-
-        userRepository.deleteById(userId);
-        // todo : 게시판, 채팅, 팀매칭, 상대팀 매칭 모든 글의 softDelete 처리를 해줘야함.
-        // todo : 댓글 및 좋아요도 해줘야한다.
-        // todo : 출석 테이블도 삭제 처리해야함.
-        // todo : 이후 스케줄러를 통해 매번 1번씩 soft 처리된 모든 필드를 삭제하는 로직을 가져가야할 것 같다.
-
+        user.userWithdrawal(nicknameService.createANicknameForDeletedUser());
     }
 
     @Transactional

--- a/src/main/java/sync/slamtalk/user/service/NicknameService.java
+++ b/src/main/java/sync/slamtalk/user/service/NicknameService.java
@@ -1,4 +1,4 @@
-package sync.slamtalk.security.oauth2.service;
+package sync.slamtalk.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,6 +10,7 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class NicknameService {
     private final UserRepository userRepository;
+    private final Random random = new Random();
 
     /**
      * 소셜 닉네임을 기반으로 사용 가능한 닉네임을 생성합니다.
@@ -25,11 +26,23 @@ public class NicknameService {
         String processedNickname = removeSpecialCharactersAndConvertToLowercase(socialNickname);
 
         if (processedNickname.length() >= 13 || isNicknameAlreadyExists(processedNickname)) {
-            return generateAnonymousNickname(1); // "익명" + 랜덤 숫자 생성
+            return generateAnonymousNickname("익명",1); // "익명" + 랜덤 숫자 생성
         }
 
         return processedNickname; // 조건에 부합하면 처리된 닉네임 반환
     }
+
+    /**
+     * 탈퇴한 사용자를 위한 익명 닉네임을 생성합니다.
+     * "탈퇴유저"라는 문자열에 뒤이어 랜덤 숫자를 결합하여 새로운 닉네임을 형성합니다.
+     * 이 메소드는 탈퇴한 사용자에게 고유한 닉네임을 제공하기 위해 사용됩니다.
+     *
+     * @return String 타입으로, "탈퇴유저"라는 문자열과 뒤에 붙는 랜덤 숫자를 결합한 새로운 닉네임을 반환합니다.
+     */
+    public String createANicknameForDeletedUser() {
+        return generateAnonymousNickname("탈퇴유저", 1); // "탈퇴유저" + 랜덤 숫자 생성
+    }
+
 
 
     /**
@@ -38,17 +51,19 @@ public class NicknameService {
      * @param depth 재귀 호출의 깊이
      * @return String 생성된 고유 닉네임
      */
-    private String generateAnonymousNickname(int depth) {
+    private String generateAnonymousNickname(String keyword, int depth) {
         int length = (depth == 1) ? 4 : (depth == 2) ? 8 : 11; // 재귀 단계에 따른 랜덤 숫자 길이
         String randomDigits = generateRandomDigits(length);
-        String newNickname = "익명" + randomDigits;
+        String newNickname = keyword + randomDigits;
 
         if (isNicknameAlreadyExists(newNickname)) {
-            return generateAnonymousNickname(depth + 1); // 재귀 호출 시 깊이 증가
+            return generateAnonymousNickname(keyword,depth + 1); // 재귀 호출 시 깊이 증가
         } else {
             return newNickname;
         }
     }
+
+
 
     /**
      * 주어진 길이에 따라 랜덤 숫자 문자열을 생성합니다.
@@ -57,7 +72,6 @@ public class NicknameService {
      * @return String 생성된 랜덤 숫자 문자열
      */
     private String generateRandomDigits(int length) {
-        Random random = new Random();
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < length; i++) {

--- a/src/main/java/sync/slamtalk/user/service/RevokeSocialLoginService.java
+++ b/src/main/java/sync/slamtalk/user/service/RevokeSocialLoginService.java
@@ -1,0 +1,140 @@
+package sync.slamtalk.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import sync.slamtalk.common.BaseException;
+import sync.slamtalk.user.entity.SocialType;
+import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.error.UserErrorResponseCode;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RevokeSocialLoginService {
+
+    public static final String googleRevokeUrl = "https://accounts.google.com/o/oauth2/revoke";
+    public static final String naverRevokeUrl = "https://nid.naver.com/oauth2.0/token";
+    public static final String kakaoRevokeUrl = "https://kapi.kakao.com/v1/user/unlink";
+
+    @Value("${spring.security.oauth2.client.registration.naver.clientId}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.clientSecret}")
+    private String naverClientSecret;
+
+    /**
+     * 사용자의 Google 계정을 삭제합니다.
+     *
+     * 이 메서드는 사용자의 OAuth2 액세스 토큰을 사용하여 Google 계정 삭제 요청을 보냅니다.
+     * 계정 삭제 요청은 {@link #sendRevokeRequest(String, SocialType, Callback)} 메서드를 통해 전송됩니다.
+     *
+     * @param user 삭제할 Google 계정의 사용자 정보를 담고 있는 {@link User} 객체입니다.
+     *             필요한 정보: OAuth2 액세스 토큰.
+     */
+    public void deleteGoogleAccount(User user) {
+        // 사용자의 OAuth2 액세스 토큰을 이용해 삭제 요청 데이터를 구성합니다.
+        String data = "token=" + user.getOauth2AccessToken();
+
+        // 실제로 Google 계정 삭제 요청을 보내는 메서드를 호출합니다.
+        sendRevokeRequest(data, SocialType.GOOGLE, null);
+    }
+
+    /**
+     * 사용자의 Naver 계정을 삭제합니다.
+     *
+     * 이 메서드는 사용자의 OAuth2 액세스 토큰과 Naver 클라이언트 ID, 클라이언트 비밀을 사용하여 Naver 계정 삭제 요청을 보냅니다.
+     * 계정 삭제 요청은 {@link #sendRevokeRequest(String, SocialType, Callback)} 메서드를 통해 전송됩니다.
+     *
+     * @param user 삭제할 Naver 계정의 사용자 정보를 담고 있는 {@link User} 객체입니다.
+     *             필요한 정보: OAuth2 액세스 토큰.
+     */
+    public void deleteNaverAccount(User user) {
+        // 사용자의 OAuth2 액세스 토큰과 Naver 클라이언트 ID, 클라이언트 비밀을 이용해 삭제 요청 데이터를 구성합니다.
+        String data = "client_id=" + naverClientId +
+                "&client_secret=" + naverClientSecret +
+                "&access_token=Bearer " + user.getOauth2AccessToken() +
+                "&grant_type=delete";
+
+        // 실제로 Naver 계정 삭제 요청을 보내는 메서드를 호출합니다.
+        sendRevokeRequest(data, SocialType.NAVER, null);
+    }
+
+    /**
+     * 사용자의 카카오 계정과 관련된 OAuth2 액세스 토큰을 사용하여 카카오 로그인 연동 해제를 요청하는 메소드입니다.
+     * 이 메소드는 사용자가 소셜 로그인 연동을 해제하고자 할 때 호출되며, 카카오 계정의 연동 해제를 위한 HTTP 요청을 전송합니다.
+     * 내부적으로 `sendRevokeRequest` 메소드를 호출하여 실제 연동 해제 요청을 처리합니다.
+     *
+     * @param user 연동 해제를 요청하는 사용자 객체입니다. 이 객체에서 카카오 OAuth2 액세스 토큰을 추출하여 사용합니다.
+     *             사용자 객체는 null이 아니어야 하며, 유효한 카카오 OAuth2 액세스 토큰을 포함하고 있어야 합니다.
+     *             만약 사용자 객체가 null이거나 유효하지 않은 액세스 토큰을 포함하고 있을 경우, 연동 해제 요청은 실패할 것입니다.
+     *
+     * @return 이 메소드는 반환값이 없습니다(void).
+     */
+    public void deleteKakaoAccount(User user) {
+
+        sendRevokeRequest(null, SocialType.KAKAO, user.getOauth2AccessToken());
+    }
+
+
+    /**
+     * 소셜 미디어 계정 연결 해제를 위한 요청을 전송하는 메서드입니다.
+     * Google, Naver, Kakao 등 지원하는 소셜 미디어 플랫폼에 따라 적절한 API를 호출하여 사용자의 소셜 미디어 계정과의 연결을 해제합니다.
+     * 이 메서드는 HTTP POST 요청을 사용하여 소셜 미디어 서비스의 연결 해제(endpoints)에 요청을 보냅니다.
+     * 요청이 성공하면, 해당 소셜 미디어 계정과의 연결이 해제되며, 실패할 경우 사용자는 다시 로그인해야 할 수 있습니다.
+     *
+     * @param data 전송할 데이터입니다. 이 데이터는 소셜 미디어 플랫폼에 따라 다를 수 있으며,
+     *             일반적으로 사용자 식별 정보나 토큰 취소 요청에 필요한 정보를 포함합니다.
+     * @param socialType 소셜 미디어의 종류를 나타내는 {@code SocialType} 열거형입니다.
+     *                   GOOGLE, NAVER, KAKAO 중 하나를 지정할 수 있습니다.
+     * @param accessToken 사용자의 액세스 토큰입니다. Kakao의 경우, Bearer 토큰 인증 방식으로 사용되어
+     *                    요청 헤더에 추가됩니다.
+     *
+     * 이 메서드는 반환 값이 없습니다(void). 하지만 내부적으로 요청의 성공 여부를 확인하고,
+     * 요청이 실패하면 BaseException을 던집니다. 이는 요청 처리 중 발생한 문제를 호출자에게 알리는 방법입니다.
+     * 성공적으로 요청이 처리되면, debug 로그를 통해 응답 상태 코드와 응답 본문을 기록합니다.
+     *
+     * 주의: 이 메서드는 private 접근 제한자를 사용하여 클래스 내부에서만 사용할 수 있도록 설계되었습니다.
+     * 외부에서 직접 호출할 수 없으며, 클래스 내 다른 메서드를 통해 간접적으로 사용됩니다.
+     */
+    private void sendRevokeRequest(
+            String data,
+            SocialType socialType,
+            String accessToken
+    ) {
+
+        RestTemplate restTemplate = new RestTemplate();
+        String revokeUrl = "";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<String> entity = new HttpEntity<>(data, headers);
+
+        switch (socialType) {
+            case GOOGLE -> revokeUrl = googleRevokeUrl;
+            case NAVER -> revokeUrl = naverRevokeUrl;
+            case KAKAO -> {
+                revokeUrl = kakaoRevokeUrl;
+                headers.setBearerAuth(accessToken);
+            }
+            default -> throw new BaseException(UserErrorResponseCode.SOCIAL_TYPE_DOESNT_EXIST);
+        }
+
+        ResponseEntity<String> responseEntity = restTemplate.exchange(revokeUrl, HttpMethod.POST, entity, String.class);
+
+        // 응답 상태 코드와 본문을 가져옵니다.
+        HttpStatus statusCode = (HttpStatus) responseEntity.getStatusCode();
+        String responseBody = responseEntity.getBody();
+
+        if (!statusCode.equals(HttpStatus.OK)) throw new BaseException(UserErrorResponseCode.NEED_TO_LOG_IN_AGAIN);
+
+        log.debug("소셜 회원 연결 해체 요청 결과, Status Code: " + statusCode + ", Response : " + responseBody);
+
+    }
+
+}

--- a/src/test/java/sync/slamtalk/security/oauth2/service/NicknameServiceTest.java
+++ b/src/test/java/sync/slamtalk/security/oauth2/service/NicknameServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.entity.User;
+import sync.slamtalk.user.service.NicknameService;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,7 +37,7 @@ class NicknameServiceTest {
         String generatedNickname = nicknameService.createAvailableNickname(nickname);
 
         // then
-        assertEquals(generatedNickname, "테스트닉네임");
+        assertEquals(generatedNickname, nickname);
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).
- [x] softDelete 처리, 이메일, 비밀번호, 닉네임, ROLE 등 필수 정보 대체하기
- [x] other-info 조회 시, 탈퇴한 유저도 프로필 조회가 가능하도록 수정 SocialType - NONE 제공하기
- [x] 스프링 시큐리티에 ROLE  탈퇴한 유저 탈퇴한 유저
- [x] 스프링 시큐리티 제외 경로 List로 관리하는 별도의 클래스 만들어 리팩터링하기 


## 💬 리뷰 요구사항 (선택)
- RDB User 제약조건 변경되었습니다. 

resolved : #321 
