### PR TITLE
#337  소셜 로그인은 비밀번호 변경 지원 안함.

### DIFF
--- a/src/main/java/sync/slamtalk/user/error/UserErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/user/error/UserErrorResponseCode.java
@@ -18,7 +18,8 @@ public enum UserErrorResponseCode implements ResponseCodeDetails {
     ALREADY_CANCEL_USER(SC_BAD_REQUEST, 4010, "회원탈퇴 후 7일 동안 재가입이 불가능합니다"),
     FAILED_TO_CREATE_TEMPORARY_PASSWORD_ISSUANCE(SC_INTERNAL_SERVER_ERROR, 4011, "임시 비밀번호 재발급이 실패하였습니다"),
     NEED_TO_LOG_IN_AGAIN(SC_BAD_REQUEST, 4012, "회원 탈퇴를 진행하기 위해서는 다시 로그인해야 합니다."),
-    SOCIAL_TYPE_DOESNT_EXIST(SC_BAD_REQUEST, 4013, "잘못된 접근입니다");
+    SOCIAL_TYPE_DOESNT_EXIST(SC_BAD_REQUEST, 4013, "잘못된 접근입니다"),
+    SOCIAL_LOGIN_PASSWORD_CHANGE_NOT_SUPPORTED(SC_BAD_REQUEST, 4014, "소셜로그인의 경우 비밀번호 변경 기능은 사용 불가능합니다.") ;
     ;
 
     private final int code;

--- a/src/main/java/sync/slamtalk/user/service/AuthService.java
+++ b/src/main/java/sync/slamtalk/user/service/AuthService.java
@@ -233,6 +233,8 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(UserErrorResponseCode.NOT_FOUND_USER));
 
+        if(!SocialType.LOCAL.equals(user.getSocialType())) throw new BaseException(UserErrorResponseCode.SOCIAL_LOGIN_PASSWORD_CHANGE_NOT_SUPPORTED);
+
         // 찾은 사용자의 비밀번호를 업데이트합니다. 새 비밀번호는 암호화되어 저장합니다.
         user.updatePassword(passwordEncoder.encode(password));
 


### PR DESCRIPTION
## 📝 작업 내용

- 소셜 타입이 LOCAL 일 경우에만 비밀번호 수정가능하게 그 외는 에러를 던지게끔 요구사항 변경

resolved #337