### PR TITLE
[팀매칭/상대팀매칭] 약속시간 검증로직 추가

### DIFF
--- a/src/main/java/sync/slamtalk/mate/error/MateErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/mate/error/MateErrorResponseCode.java
@@ -17,7 +17,10 @@ public enum MateErrorResponseCode implements ResponseCodeDetails {
     MATE_POST_ALREADY_CANCELED_OR_COMPLETED(SC_BAD_REQUEST, 4006, "이미 취소 되었거나 모집 완료된 글입니다."),
     NOT_ALLOWED_TO_PARTICIPATE(SC_BAD_REQUEST, 4008, "해당 글에 참여할 수 없습니다."),
     NO_ACCEPTED_PARTICIPANT(SC_BAD_REQUEST, 4009, "수락된 참여자가 없습니다."),
-    MATE_POST_ALREADY_DELETED(SC_BAD_REQUEST, 4010, "이미 삭제된 글입니다.");
+    MATE_POST_ALREADY_DELETED(SC_BAD_REQUEST, 4010, "이미 삭제된 글입니다."),
+    APPOINTMENT_DATE_ERROR(SC_BAD_REQUEST, 4043, "약속날짜는 현재날짜와 같거나 그 이후여야 합니다."),
+    APPOINTMENT_TIME_ERROR(SC_BAD_REQUEST, 4044, "약속시간이 현재시간 이후여야 합니다.")
+    ;
 
     MateErrorResponseCode(int code, int status, String message) {
         this.code = code;
@@ -44,7 +47,4 @@ public enum MateErrorResponseCode implements ResponseCodeDetails {
         return this.message;
     }
 
-    public void setMessage(String message) {
-        this.message = message;
-    }
 }

--- a/src/main/java/sync/slamtalk/mate/service/MatePostService.java
+++ b/src/main/java/sync/slamtalk/mate/service/MatePostService.java
@@ -331,7 +331,7 @@ public class MatePostService {
      *         예약 날짜가 현재 날짜보다 이전인 경우 APPOINTMENT_DATE_ERROR 예외가,
      *         예약 날짜는 같지만 예약 시작 시간이 현재 시간보다 이전 또는 같은 경우 APPOINTMENT_TIME_ERROR 예외가 발생합니다.
      */
-    private boolean checkAppointmentTime(MatePostReq matePostReq){
+    private void checkAppointmentTime(MatePostReq matePostReq){
         // 현재 날짜가 예약 날짜보다 뒤인 경우
         if(LocalDate.now().isAfter(matePostReq.getScheduledDate())) throw new BaseException(APPOINTMENT_DATE_ERROR);
 
@@ -339,6 +339,5 @@ public class MatePostService {
         if(LocalDate.now().isEqual(matePostReq.getScheduledDate())
                 && !LocalTime.now().isBefore(matePostReq.getStartTime())) throw new BaseException(APPOINTMENT_TIME_ERROR);
 
-        return true;
     }
 }

--- a/src/main/java/sync/slamtalk/team/error/TeamErrorResponseCode.java
+++ b/src/main/java/sync/slamtalk/team/error/TeamErrorResponseCode.java
@@ -16,7 +16,10 @@ public enum TeamErrorResponseCode implements ResponseCodeDetails {
     OVER_LIMITED_NUMBERS(SC_BAD_REQUEST, 4011, "모집 인원을 초과하여 지원할 수 없습니다."),
     APPLICANT_NOT_FOUND(SC_NOT_FOUND, 4042, "해당 지원자를 찾을 수 없습니다."),
     OPPONENT_NOT_DECLARED(SC_BAD_REQUEST, 4012, "상대팀이 선언되지 않은 글입니다."),
-    NOT_ALLOWED_REQUEST(SC_BAD_REQUEST, 4013, "요청이 허용되지 않습니다.");
+    NOT_ALLOWED_REQUEST(SC_BAD_REQUEST, 4013, "요청이 허용되지 않습니다."),
+    APPOINTMENT_DATE_ERROR(SC_BAD_REQUEST, 4043, "약속날짜는 현재날짜와 같거나 그 이후여야 합니다."),
+    APPOINTMENT_TIME_ERROR(SC_BAD_REQUEST, 4044, "약속시간이 현재시간 이후여야 합니다.")
+    ;
 
     TeamErrorResponseCode(int code, int status, String message) {
         this.code = code;
@@ -43,7 +46,4 @@ public enum TeamErrorResponseCode implements ResponseCodeDetails {
         return this.message;
     }
 
-    public void setMessage(String message) {
-        this.message = message;
-    }
 }

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -16,12 +16,15 @@ import sync.slamtalk.team.dto.response.MyTeamMatchingListRes;
 import sync.slamtalk.team.dto.response.TeamMatchingKeyInformation;
 import sync.slamtalk.team.entity.TeamApplicant;
 import sync.slamtalk.team.entity.TeamMatching;
+import sync.slamtalk.team.error.TeamErrorResponseCode;
 import sync.slamtalk.team.event.*;
 import sync.slamtalk.team.repository.TeamApplicantRepository;
 import sync.slamtalk.team.repository.TeamMatchingRepository;
 import sync.slamtalk.user.UserRepository;
 import sync.slamtalk.user.entity.User;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -49,6 +52,9 @@ public class TeamMatchingService {
      * 2. FromTeamFormDTO를 TeamMatching 객체로 변환하여 저장한다.
      */
     public long registerTeamMatching(FromTeamFormDTO dto, long userId) {
+        // 약속 시간 검증
+        checkAppointmentTime(dto);
+
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(NOT_FOUND_USER));
         log.debug("[TeamMatchingService] user : {}", user.getTeamMatchings());
         TeamMatching teamMatchingEntity = new TeamMatching();
@@ -85,6 +91,9 @@ public class TeamMatchingService {
      * 4. 글을 수정한다.
      */
     public void updateTeamMatching(Long teamMatchingId, FromTeamFormDTO fromTeamFormDTO, Long userId) {
+        // 약속 시간 검증
+        checkAppointmentTime(fromTeamFormDTO);
+
         TeamMatching teamMatchingEntity = teamMatchingRepository.findById(teamMatchingId).orElseThrow(() -> new BaseException(TEAM_POST_NOT_FOUND));
         if (Boolean.TRUE.equals(teamMatchingEntity.getIsDeleted())) {
             throw new BaseException(TEAM_POST_ALREADY_DELETED);
@@ -383,5 +392,26 @@ public class TeamMatchingService {
                 allByWriter.stream().map(TeamMatchingKeyInformation::ofMyPost).toList(),
                 allByApplications.stream().map(t -> TeamMatchingKeyInformation.ofParticipantPost(t, userId)).toList()
         );
+    }
+
+    /**
+     * 예약 날짜와 시간을 검사하여 유효성을 확인하는 메소드.
+     *
+     * @param matePostReq 예약 요청 정보를 담고 있는 MatePostReq 객체. 예약 날짜와 시작 시간 정보를 포함합니다.
+     * @return 유효성 검사를 통과하면 true를 반환합니다. 이 메소드에서는 유효성 검사에 실패하면 예외를 발생시키므로,
+     *         유효성 검사를 통과한 경우에만 true를 반환하는 것으로 처리되어 있습니다.
+     * @throws BaseException 예약 날짜 또는 시간이 현재 날짜 및 시간보다 이전인 경우 예외를 발생시킵니다.
+     *         예약 날짜가 현재 날짜보다 이전인 경우 APPOINTMENT_DATE_ERROR 예외가,
+     *         예약 날짜는 같지만 예약 시작 시간이 현재 시간보다 이전 또는 같은 경우 APPOINTMENT_TIME_ERROR 예외가 발생합니다.
+     */
+    private boolean checkAppointmentTime(FromTeamFormDTO fromTeamFormDTO){
+        // 현재 날짜가 예약 날짜보다 뒤인 경우
+        if(LocalDate.now().isAfter(fromTeamFormDTO.getScheduledDate())) throw new BaseException(TeamErrorResponseCode.APPOINTMENT_DATE_ERROR);
+
+        // 현재 날짜가 예약 날짜와 같고, 현재 시간이 예약 시작 시간보다 같거나 늦은 경우
+        if(LocalDate.now().isEqual(fromTeamFormDTO.getScheduledDate())
+                && !LocalTime.now().isBefore(fromTeamFormDTO.getStartTime())) throw new BaseException(TeamErrorResponseCode.APPOINTMENT_TIME_ERROR);
+
+        return true;
     }
 }

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -397,7 +397,7 @@ public class TeamMatchingService {
     /**
      * 예약 날짜와 시간을 검사하여 유효성을 확인하는 메소드.
      *
-     * @param matePostReq 예약 요청 정보를 담고 있는 MatePostReq 객체. 예약 날짜와 시작 시간 정보를 포함합니다.
+     * @param fromTeamFormDTO 예약 요청 정보를 담고 있는 FromTeamFormDTO 객체. 예약 날짜와 시작 시간 정보를 포함합니다.
      * @return 유효성 검사를 통과하면 true를 반환합니다. 이 메소드에서는 유효성 검사에 실패하면 예외를 발생시키므로,
      *         유효성 검사를 통과한 경우에만 true를 반환하는 것으로 처리되어 있습니다.
      * @throws BaseException 예약 날짜 또는 시간이 현재 날짜 및 시간보다 이전인 경우 예외를 발생시킵니다.


### PR DESCRIPTION
## 📝 작업 내용
- 상대팀매칭 등록 및 수정 시 약속시간 검증 로직 추가
- 팀매칭게시글 등록 및 수정 시 약속시간 검증하는 로직 추가

검증로직 
예약 날짜 또는 시간이 현재 날짜 및 시간보다 이전인 경우 예외를 발생시킵니다.
- 예약 날짜가 현재 날짜보다 이전인 경우 APPOINTMENT_DATE_ERROR 예외가,
- 예약 날짜는 같지만 예약 시작 시간이 현재 시간보다 이전 또는 같은 경우 APPOINTMENT_TIME_ERROR 예외가 발생합니다.