### PR TITLE
[팀매칭/메이트매칭] 게시글 시간 검증 로직 수정

### DIFF
--- a/src/main/java/sync/slamtalk/mate/service/MatePostService.java
+++ b/src/main/java/sync/slamtalk/mate/service/MatePostService.java
@@ -339,6 +339,6 @@ public class MatePostService {
         if(LocalDate.now().isEqual(matePostReq.getScheduledDate())
                 && !LocalTime.now().isBefore(matePostReq.getStartTime())) throw new BaseException(APPOINTMENT_TIME_ERROR);
 
-        if(matePostReq.getStartTime().isBefore(matePostReq.getEndTime())) throw new BaseException(START_TIME_END_TIME_ERROR);
+        if(matePostReq.getStartTime().isAfter(matePostReq.getEndTime())) throw new BaseException(START_TIME_END_TIME_ERROR);
     }
 }

--- a/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
+++ b/src/main/java/sync/slamtalk/team/service/TeamMatchingService.java
@@ -412,7 +412,7 @@ public class TeamMatchingService {
         if(LocalDate.now().isEqual(fromTeamFormDTO.getScheduledDate())
                 && !LocalTime.now().isBefore(fromTeamFormDTO.getStartTime())) throw new BaseException(TeamErrorResponseCode.APPOINTMENT_TIME_ERROR);
 
-        if(fromTeamFormDTO.getStartTime().isBefore(fromTeamFormDTO.getEndTime())) throw new BaseException(TeamErrorResponseCode.START_TIME_END_TIME_ERROR);
+        if(fromTeamFormDTO.getStartTime().isAfter(fromTeamFormDTO.getEndTime())) throw new BaseException(TeamErrorResponseCode.START_TIME_END_TIME_ERROR);
 
         return true;
     }


### PR DESCRIPTION
- 시작시간이 종료시간 이전이야함.

